### PR TITLE
945 add padding and shadow to geomap tooltip

### DIFF
--- a/webapp/src/routes/RewardsDistribution/index.js
+++ b/webapp/src/routes/RewardsDistribution/index.js
@@ -161,7 +161,8 @@ const RewardsDistribution = () => {
       aria-owns={open ? 'mouse-over-popover' : undefined}
       aria-haspopup="true"
     >
-      <Popover className={classes.boxShadow}
+      <Popover
+        className={classes.root}
         onMouseEnter={handlePopoverOpen}
         onMouseLeave={handlePopoverClose}
         sx={{
@@ -180,7 +181,8 @@ const RewardsDistribution = () => {
         onClose={handlePopoverClose}
         id="mouse-over-popover"
       >
-        <Box className={classes.boxPadding}
+        <Box
+          className={classes.boxPadding}
           sx={{
             pointerEvents: 'auto',
           }}
@@ -374,7 +376,7 @@ const RewardsDistribution = () => {
         </div>
       </div>
       {!loading && (
-        <Paper className={classes.mapWrapper}>
+        <Paper className={[classes.mapWrapper,classes.cardShadow]}>
           <ComposableMap
             projectionConfig={{
               scale: 170,

--- a/webapp/src/routes/RewardsDistribution/index.js
+++ b/webapp/src/routes/RewardsDistribution/index.js
@@ -280,7 +280,7 @@ const RewardsDistribution = () => {
         </div>
         <div className={classes.rewardsdiv}>
           <Card
-            className={[classes.action, classes.cardShadow]}
+            className={`${classes.action} ${classes.cardShadow}`}
             onClick={handlePopoverOpen(summary?.topCountryByRewards)}
           >
             <CardContent>
@@ -376,7 +376,7 @@ const RewardsDistribution = () => {
         </div>
       </div>
       {!loading && (
-        <Paper className={[classes.mapWrapper,classes.cardShadow]}>
+        <Paper className={`${classes.mapWrapper} ${classes.cardShadow}`}>
           <ComposableMap
             projectionConfig={{
               scale: 170,

--- a/webapp/src/routes/RewardsDistribution/index.js
+++ b/webapp/src/routes/RewardsDistribution/index.js
@@ -161,7 +161,7 @@ const RewardsDistribution = () => {
       aria-owns={open ? 'mouse-over-popover' : undefined}
       aria-haspopup="true"
     >
-      <Popover
+      <Popover className={classes.boxShadow}
         onMouseEnter={handlePopoverOpen}
         onMouseLeave={handlePopoverClose}
         sx={{
@@ -180,7 +180,7 @@ const RewardsDistribution = () => {
         onClose={handlePopoverClose}
         id="mouse-over-popover"
       >
-        <Box
+        <Box className={classes.boxPadding}
           sx={{
             pointerEvents: 'auto',
           }}
@@ -244,7 +244,7 @@ const RewardsDistribution = () => {
       {loading && <LinearProgress className={classes.linearLoader} />}
       <div className={classes.flexdad}>
         <div className={classes.mainReward}>
-          <Card>
+          <Card className={classes.cardShadow}>
             <CardContent>
               <Typography variant="h6">{t('dailyRewards')}</Typography>
               <Typography variant="subtitle1">
@@ -278,7 +278,7 @@ const RewardsDistribution = () => {
         </div>
         <div className={classes.rewardsdiv}>
           <Card
-            className={classes.action}
+            className={[classes.action, classes.cardShadow]}
             onClick={handlePopoverOpen(summary?.topCountryByRewards)}
           >
             <CardContent>
@@ -318,7 +318,7 @@ const RewardsDistribution = () => {
           </Card>
         </div>
         <div className={classes.rewardsdiv}>
-          <Card>
+          <Card className={classes.cardShadow}>
             <CardContent>
               <Typography variant="h6">{t('paidProducers')}</Typography>
               <Typography
@@ -347,7 +347,7 @@ const RewardsDistribution = () => {
           </Card>
         </div>
         <div className={classes.rewardsdiv}>
-          <Card>
+          <Card className={classes.cardShadow}>
             <CardContent>
               <Typography variant="h6" className={classes.rewardsColorSchema}>
                 <span className={classes.itemLabel}>

--- a/webapp/src/routes/RewardsDistribution/styles.js
+++ b/webapp/src/routes/RewardsDistribution/styles.js
@@ -47,6 +47,7 @@ export default (theme, lowestRewardsColor, highestRewardsColor) => ({
   },
   mapWrapper: {
     marginTop: theme.spacing(3),
+    boxShadow: '0px 0px 14px rgba(53, 64, 82, 0.35) !important'
   },
   flexdad: {
     flexDirection: 'row',
@@ -58,5 +59,11 @@ export default (theme, lowestRewardsColor, highestRewardsColor) => ({
   },
   mainReward: {
     flexGrow: 1,
+  },
+  boxPadding:{
+    padding: '10px'
+  },
+  boxShadow:{
+    boxShadow: '10px 5px 5px red !important',
   },
 })

--- a/webapp/src/routes/RewardsDistribution/styles.js
+++ b/webapp/src/routes/RewardsDistribution/styles.js
@@ -68,6 +68,6 @@ export default (theme, lowestRewardsColor, highestRewardsColor) => ({
     padding: '10px',
   },
   cardShadow: {
-    boxShadow: '0px 0px 14px rgba(255, 0, 0, 0.35) !important',
+    boxShadow: '0px 0px 14px rgba(53, 64, 82, 0.35) !important',
   },
 })

--- a/webapp/src/routes/RewardsDistribution/styles.js
+++ b/webapp/src/routes/RewardsDistribution/styles.js
@@ -46,9 +46,8 @@ export default (theme, lowestRewardsColor, highestRewardsColor) => ({
     minWidth: 120,
   },
   mapWrapper: {
-    marginTop: theme.spacing(3),
-    boxShadow: '0px 0px 14px rgba(53, 64, 82, 0.35) !important'
-  },
+    marginTop: theme.spacing(3)
+    },
   flexdad: {
     flexDirection: 'row',
     display: 'flex',
@@ -60,10 +59,15 @@ export default (theme, lowestRewardsColor, highestRewardsColor) => ({
   mainReward: {
     flexGrow: 1,
   },
-  boxPadding:{
-    padding: '10px'
+  root: {
+    '& .MuiPaper-root': {
+      boxShadow: '0px 0px 14px rgba(53, 64, 82, 0.35) !important',
+    },
   },
-  boxShadow:{
-    boxShadow: '10px 5px 5px red !important',
+  boxPadding: {
+    padding: '10px',
+  },
+  cardShadow: {
+    boxShadow: '0px 0px 14px rgba(255, 0, 0, 0.35) !important',
   },
 })


### PR DESCRIPTION
### What does this PR do?

- Resolve #945 

### Steps to test

1. Navigate to Rewards Distribution

![image](https://user-images.githubusercontent.com/55892352/194405455-a1220515-8d06-4699-b50d-2c111282a94c.png)

#### CheckList

- [x] Added Card Shadow to match main page
- [x] Added Popover padding and shadow
