### PR TITLE
Fix/accounts not found 1047

### DIFF
--- a/webapp/src/language/en.json
+++ b/webapp/src/language/en.json
@@ -162,7 +162,8 @@
     "tableNotFound": "Table not found",
     "successMessage": "Success transaction",
     "placeholder": "Account or Contract Name",
-    "title": "Search for account information, view tables and execute actions for any contract."
+    "title": "Search for account information, view tables and execute actions for any contract.",
+    "endpointFailure": "Endpoint failure"
   },
   "bpJsonRoute": {
     "loadText": "Loading node information . . .",

--- a/webapp/src/language/es.json
+++ b/webapp/src/language/es.json
@@ -167,7 +167,8 @@
     "tableNotFound": "Tabla no encontrada",
     "successMessage": "Transacción exitosa",
     "placeholder": "Cuenta o Nombre del Contrato",
-    "title": "Busque información de cuenta, vea tablas y ejecute acciones para cualquier contrato."
+    "title": "Busque información de cuenta, vea tablas y ejecute acciones para cualquier contrato.",
+    "endpointFailure": "Fallo en el endpoint"
   },
   "bpJsonRoute": {
     "loadText": "Cargando información del nodo . . .",

--- a/webapp/src/routes/Accounts/index.js
+++ b/webapp/src/routes/Accounts/index.js
@@ -9,7 +9,7 @@ import queryString from 'query-string'
 import CardContent from '@mui/material/CardContent'
 
 import { signTransaction } from '../../utils/eos'
-import eosApi from '../../utils/eosapi'
+import eosApi, { ENDPOINTS_ERROR } from '../../utils/eosapi'
 import getTransactionUrl from '../../utils/get-transaction-url'
 import { useSnackbarMessageState } from '../../context/snackbar-message.context'
 import SearchBar from '../../components/SearchBar'
@@ -96,7 +96,10 @@ const Accounts = ({ ual }) => {
       } catch (error) {
         showMessage({
           type: 'error',
-          content: t('tableNotFound'),
+          content:
+            error?.message === ENDPOINTS_ERROR
+              ? 'Endpoint Failure'
+              : t('tableNotFound'),
         })
       }
       setLoading(false)
@@ -122,7 +125,10 @@ const Accounts = ({ ual }) => {
     } catch (error) {
       showMessage({
         type: 'error',
-        content: t('accountNotFound'),
+        content:
+          error?.message === ENDPOINTS_ERROR
+            ? 'Endpoint Failure'
+            : t('accountNotFound'),
       })
     }
 

--- a/webapp/src/routes/Accounts/index.js
+++ b/webapp/src/routes/Accounts/index.js
@@ -98,7 +98,7 @@ const Accounts = ({ ual }) => {
           type: 'error',
           content:
             error?.message === ENDPOINTS_ERROR
-              ? 'Endpoint Failure'
+              ? t('endpointFailure')
               : t('tableNotFound'),
         })
       }
@@ -127,7 +127,7 @@ const Accounts = ({ ual }) => {
         type: 'error',
         content:
           error?.message === ENDPOINTS_ERROR
-            ? 'Endpoint Failure'
+            ? t('endpointFailure')
             : t('accountNotFound'),
       })
     }

--- a/webapp/src/utils/eosapi.js
+++ b/webapp/src/utils/eosapi.js
@@ -2,9 +2,11 @@ import EosApi from 'eosjs-api'
 
 import { eosConfig } from '../config'
 
-export const ENDPOINTS_ERROR = 'Each endpoint failed when trying to execute the function'
+export const ENDPOINTS_ERROR =
+  'Each endpoint failed when trying to execute the function'
+
 const waitRequestInterval = 300000
-const eosApis = eosConfig.endpoints.map((endpoint) => {
+const eosApis = eosConfig.endpoints.map(endpoint => {
   return {
     api: EosApi({
       httpEndpoint: endpoint,
@@ -32,7 +34,7 @@ const callEosApi = async method => {
         apiError = JSON.parse(error?.message)
       } catch (error) {}
 
-      if(apiError?.error) throw error
+      if (apiError?.error) throw error
 
       eosApi.lastFailureTime = new Date()
     }

--- a/webapp/src/utils/eosapi.js
+++ b/webapp/src/utils/eosapi.js
@@ -2,6 +2,7 @@ import EosApi from 'eosjs-api'
 
 import { eosConfig } from '../config'
 
+export const ENDPOINTS_ERROR = 'Each endpoint failed when trying to execute the function'
 const waitRequestInterval = 300000
 const eosApis = eosConfig.endpoints.map((endpoint) => {
   return {
@@ -25,11 +26,19 @@ const callEosApi = async method => {
 
       return response
     } catch (error) {
+      let apiError
+
+      try {
+        apiError = JSON.parse(error?.message)
+      } catch (error) {}
+
+      if(apiError?.error) throw error
+
       eosApi.lastFailureTime = new Date()
     }
   }
 
-  throw new Error('Each endpoint failed when trying to execute the function')
+  throw new Error(ENDPOINTS_ERROR)
 }
 
 const getAbi = async account => {


### PR DESCRIPTION
### Fix bug on Accounts and Contracts page

### What does this PR do?

- Resolve #1047 
- Fix the table not found bug, this was because the default table when it's no provided by url parameter was "producers", so any account without this table show an error
- Fix the bug that caused that when searching for account that doesn't exists, cause that any following value show an error

When searching for an account that doesn't exist causes an error, this would cause the endpoint to be considered as not working and wait to be queried again, consuming the entire endpoint list.

### Steps to test

1. Run the project locally with libre network
2. Go to Accounts and Contracts page
3. Search for the account "stake.libre" 
4. Should not display any errors
5. Search for an account that doesn't exists
6. Should display an error
7. Search for the account "eosio"
8. Should display that account with the producers table

### Screenshot

### Account that doesn't exists
![imagen](https://user-images.githubusercontent.com/66583677/201370619-ff317d9e-144b-4084-910b-fe83d903d467.png)

### Table that doesn't exists
![imagen](https://user-images.githubusercontent.com/66583677/201370685-be1092a8-c08e-42d7-8a26-59aac1cb51e0.png)

### Each endpoint of the list fails
![imagen](https://user-images.githubusercontent.com/66583677/201370720-b578957d-40e4-4e59-bb3b-71469e5f859e.png)

![imagen](https://user-images.githubusercontent.com/66583677/201370758-69c4ecd3-57e2-4e72-b222-44fb9f82205e.png)

