### PR TITLE
Fix/load bp jsons 1053

### DIFF
--- a/hapi/src/config/eos.config.js
+++ b/hapi/src/config/eos.config.js
@@ -10,6 +10,7 @@ module.exports = {
     process.env.HAPI_EOS_STATE_HISTORY_PLUGIN_ENDPOINT,
   chainId: process.env.HAPI_EOS_API_CHAIN_ID,
   eosChainId: 'aca376f206b8fc25a6ed44dbdc66547c36c6c33e3a119ffbeaef943642f0e906',
+  eosTopLimit: 150,
   baseAccount: process.env.HAPI_EOS_BASE_ACCOUNT,
   baseAccountPassword: process.env.HAPI_EOS_BASE_ACCOUNT_PASSWORD,
   faucet: {

--- a/hapi/src/config/eos.config.js
+++ b/hapi/src/config/eos.config.js
@@ -10,7 +10,7 @@ module.exports = {
     process.env.HAPI_EOS_STATE_HISTORY_PLUGIN_ENDPOINT,
   chainId: process.env.HAPI_EOS_API_CHAIN_ID,
   eosChainId: 'aca376f206b8fc25a6ed44dbdc66547c36c6c33e3a119ffbeaef943642f0e906',
-  eosTopLimit: 150,
+  eosTopLimit: 100,
   baseAccount: process.env.HAPI_EOS_BASE_ACCOUNT,
   baseAccountPassword: process.env.HAPI_EOS_BASE_ACCOUNT_PASSWORD,
   faucet: {

--- a/hapi/src/services/eosio.service.js
+++ b/hapi/src/services/eosio.service.js
@@ -72,7 +72,7 @@ const getProducers = async () => {
 
 const getBPJsons = async (producers = []) => {
   const isEosNetwork = eosConfig.chainId === eosConfig.eosChainId
-  let topProducers = producers.slice(0,eosConfig.eosTopLimit)
+  let topProducers = producers.slice(0, eosConfig.eosTopLimit)
 
   topProducers = await Promise.all(
     topProducers.map(async producer => {

--- a/hapi/src/services/producer.service.js
+++ b/hapi/src/services/producer.service.js
@@ -4,6 +4,7 @@ const { eosConfig } = require('../config')
 const lacchainService = require('./lacchain.service')
 const eosioService = require('./eosio.service')
 const nodeService = require('./node.service')
+const statsService = require('./stats.service')
 
 const updateProducers = async (producers = []) => {
   const upsertMutation = `
@@ -51,6 +52,11 @@ const syncProducers = async () => {
     producers = await updateProducers(producers)
     await syncNodes(producers)
     await syncEndpoints()
+
+    if (!eosConfig.stateHistoryPluginEndpoint) {
+      await statsService.sync()
+    }
+      
   }
 }
 

--- a/hapi/src/utils/axios.util.js
+++ b/hapi/src/utils/axios.util.js
@@ -3,7 +3,7 @@ const http = require('http')
 const https = require('https')
 
 const instance = axios.create({
-  timeout: 100000,
+  timeout: 30000,
   httpAgent: new http.Agent({ timeout: 300000 }),
   httpsAgent: new https.Agent({
     rejectUnauthorized: false,

--- a/hapi/src/utils/eos.util.js
+++ b/hapi/src/utils/eos.util.js
@@ -55,16 +55,21 @@ const callEosApi = async (funcName, method) => {
 }
 
 const callWithTimeout = async (promise, ms) => {
-  const timeoutPromise = new Promise((_resolve, reject) =>
-    setTimeout(() =>
+  let timeoutID
+  const timeoutPromise = new Promise((_resolve, reject) => {
+    timeoutID = setTimeout(() =>
         reject({
           message: `timeout error: the endpoint took more than ${ms} ms to respond`
         }),
       ms
-    )
+    )}
   )
 
-  return Promise.race([promise, timeoutPromise])
+  return Promise.race([promise, timeoutPromise]).then((response) => {
+    clearTimeout(timeoutID)
+
+    return response
+  })
 }
 
 const newAccount = async accountName => {

--- a/hapi/src/utils/eos.util.js
+++ b/hapi/src/utils/eos.util.js
@@ -56,14 +56,10 @@ const callEosApi = async (funcName, method) => {
 
 const callWithTimeout = async (promise, ms) => {
   let timeoutID
+  const timeoutMessage = `timeout error: the endpoint took more than ${ms} ms to respond`
   const timeoutPromise = new Promise((_resolve, reject) => {
-    timeoutID = setTimeout(() =>
-        reject({
-          message: `timeout error: the endpoint took more than ${ms} ms to respond`
-        }),
-      ms
-    )}
-  )
+    timeoutID = setTimeout(() => reject({ message: timeoutMessage }), ms)
+  })
 
   return Promise.race([promise, timeoutPromise]).then((response) => {
     clearTimeout(timeoutID)

--- a/hapi/src/utils/eos.util.js
+++ b/hapi/src/utils/eos.util.js
@@ -58,7 +58,7 @@ const callWithTimeout = async (promise, ms) => {
   let timeoutID
   const timeoutMessage = `timeout error: the endpoint took more than ${ms} ms to respond`
   const timeoutPromise = new Promise((_resolve, reject) => {
-    timeoutID = setTimeout(() => reject({ message: timeoutMessage }), ms)
+    timeoutID = setTimeout(() => reject(new Error(timeoutMessage)), ms)
   })
 
   return Promise.race([promise, timeoutPromise]).then((response) => {

--- a/hapi/src/workers/producers.worker.js
+++ b/hapi/src/workers/producers.worker.js
@@ -60,9 +60,9 @@ const start = async () => {
     workersConfig.syncExchangeRate
   )
   run('CPU WORKER', cpuService.worker, workersConfig.cpuWorkerInterval)
-  run('SYNC STATS INFO', statsService.sync, workersConfig.syncStatsInterval)
 
   if (eosConfig.stateHistoryPluginEndpoint) {
+    run('SYNC STATS INFO', statsService.sync, workersConfig.syncStatsInterval)
     run('SYNC BLOCK HISTORY', stateHistoryPluginService.init)
     run('SYNC MISSED BLOCKS', missedBlocksService.syncMissedBlocks)
     run('SYNC MISSED BLOCKS PER PRODUCER', statsService.getCurrentMissedBlock)


### PR DESCRIPTION
### Limit how many bpjsons are requested

### What does this PR do?

- Resolve #1053
- Limit the number of BP JSONS requested to 100
- Add a timeout when an endpoint of the array is requested
- Don't use statService when stateHistoryPluginEndpoint is not provided, in that case it would be called after loading the data from the producers.

### Steps to test

1. Run the project locally
2. Check that the producers that aren't in the top 100 don't have bp.json
    and those in the top have the object


