### PR TITLE
Fix/bpjsons load

### DIFF
--- a/docs/producers-API-documentation.md
+++ b/docs/producers-API-documentation.md
@@ -7,7 +7,7 @@ Also, in the Antelope Tools backend, each API endpoint is requested through HTTP
 
 ## How is the data obtained?
 
-Through the eosjs API, the system queries the `producers` table of the eosio account, with this table, we get the URLs of the Top 100 producers to obtain their `bp.json`. When the BP JSON is not obtained the producer is not consider in the results.That information is updated every 4 hours.  
+Through the eosjs API, the system queries the `producers` table of the eosio account, with this table, we get the URLs of the Top 150 producers to obtain their `bp.json`. When the BP JSON is not obtained the producer is not consider in the results.That information is updated every 4 hours.  
 **Note:** if the BP JSON is not from the current network, the nodes are removed. 
 
 You can check the [producer's table](https://eos.antelope.tools/accounts?account=eosio&table=producers) of eosio account of the EOS Network in the section of Contract Tables.
@@ -319,7 +319,7 @@ The `owners` array is too long.
 ```json
 {
     "path": "$",
-    "error": "\"input.bpParams.owners\" must contain less than or equal to 100 items",
+    "error": "\"input.bpParams.owners\" must contain less than or equal to 150 items",
     "code": "unexpected"
 }
 ```

--- a/hapi/src/config/eos.config.js
+++ b/hapi/src/config/eos.config.js
@@ -10,7 +10,7 @@ module.exports = {
     process.env.HAPI_EOS_STATE_HISTORY_PLUGIN_ENDPOINT,
   chainId: process.env.HAPI_EOS_API_CHAIN_ID,
   eosChainId: 'aca376f206b8fc25a6ed44dbdc66547c36c6c33e3a119ffbeaef943642f0e906',
-  eosTopLimit: 100,
+  eosTopLimit: 150,
   baseAccount: process.env.HAPI_EOS_BASE_ACCOUNT,
   baseAccountPassword: process.env.HAPI_EOS_BASE_ACCOUNT_PASSWORD,
   faucet: {

--- a/hapi/src/routes/get-producers-info.route.js
+++ b/hapi/src/routes/get-producers-info.route.js
@@ -1,6 +1,7 @@
 const Boom = require('@hapi/boom')
 const Joi = require('joi')
 
+const { eosConfig } = require('../config')
 const { producerService } = require('../services')
 
 module.exports = {
@@ -25,7 +26,7 @@ module.exports = {
         input: Joi.object({
           bpParams: Joi.object({
             type: Joi.string().valid('api', 'ssl', 'p2p').optional(),
-            owners: Joi.array().items(Joi.string().required()).max(150).optional()
+            owners: Joi.array().items(Joi.string().required()).max(eosConfig.eosTopLimit).optional()
           }).required()
         }).required()
       }).options({ stripUnknown: true })

--- a/hapi/src/routes/get-producers-info.route.js
+++ b/hapi/src/routes/get-producers-info.route.js
@@ -25,7 +25,7 @@ module.exports = {
         input: Joi.object({
           bpParams: Joi.object({
             type: Joi.string().valid('api', 'ssl', 'p2p').optional(),
-            owners: Joi.array().items(Joi.string().required()).max(100).optional()
+            owners: Joi.array().items(Joi.string().required()).max(150).optional()
           }).required()
         }).required()
       }).options({ stripUnknown: true })

--- a/hapi/src/services/producer.service.js
+++ b/hapi/src/services/producer.service.js
@@ -43,6 +43,7 @@ const updateProducers = async (producers = []) => {
   topProducers = topProducers.filter(
     producer => producer?.bp_json && Object.keys(producer.bp_json).length > 0
   )
+  await nodeService.clearNodes()
   await updateBPJSONs(topProducers)
 
   const insertedRows = await hasuraUtil.request(upsertMutation, { producers })
@@ -67,7 +68,6 @@ const syncProducers = async () => {
   }
 
   if (producers?.length) {
-    await nodeService.clearNodes()
     producers = await updateProducers(producers)
     await syncNodes(producers.slice(0, eosConfig.eosTopLimit))
     await syncEndpoints()

--- a/hapi/src/services/producer.service.js
+++ b/hapi/src/services/producer.service.js
@@ -39,13 +39,16 @@ const updateProducers = async (producers = []) => {
   `
 
   let topProducers = producers.slice(0, eosConfig.eosTopLimit)
-  topProducers = topProducers.filter(prod => prod?.bp_json && Object.keys(prod.bp_json).length > 0)
+
+  topProducers = topProducers.filter(
+    producer => producer?.bp_json && Object.keys(producer.bp_json).length > 0
+  )
   await updateBPJSONs(topProducers)
 
   const insertedRows = await hasuraUtil.request(upsertMutation, { producers })
 
   await hasuraUtil.request(clearMutation, {
-    owners: producers.map((producer) => producer.owner)
+    owners: producers.map(producer => producer.owner)
   })
 
   return insertedRows.insert_producer.returning
@@ -72,7 +75,6 @@ const syncProducers = async () => {
     if (!eosConfig.stateHistoryPluginEndpoint) {
       await statsService.sync()
     }
-      
   }
 }
 
@@ -94,8 +96,8 @@ const getProducersSummary = async () => {
 const syncNodes = async producers => {
   if (!producers?.length) return
 
-  let nodes = producers.flatMap((producer) => {
-    return (producer.bp_json?.nodes || []).map((node) => {
+  let nodes = producers.flatMap(producer => {
+    return (producer.bp_json?.nodes || []).map(node => {
       node.producer_id = producer.id
 
       return nodeService.getFormatNode(node)

--- a/hapi/src/utils/axios.util.js
+++ b/hapi/src/utils/axios.util.js
@@ -3,7 +3,7 @@ const http = require('http')
 const https = require('https')
 
 const instance = axios.create({
-  timeout: 30000,
+  timeout: 100000,
   httpAgent: new http.Agent({ timeout: 300000 }),
   httpsAgent: new https.Agent({
     rejectUnauthorized: false,

--- a/webapp/src/hooks/customHooks/useBlockProducerState.js
+++ b/webapp/src/hooks/customHooks/useBlockProducerState.js
@@ -46,7 +46,7 @@ const useBlockProducerState = () => {
       ...prev,
       page: 1,
       ...filter,
-      where: { ...where, owner: prev.where?.owner },
+      where: { ...where, owner: prev.where?.owner, bp_json: {_is_null: false} },
     }))
   }, [filters, setPagination])
 

--- a/webapp/src/hooks/customHooks/useBlockProducerState.js
+++ b/webapp/src/hooks/customHooks/useBlockProducerState.js
@@ -46,7 +46,7 @@ const useBlockProducerState = () => {
       ...prev,
       page: 1,
       ...filter,
-      where: { ...where, owner: prev.where?.owner, bp_json: {_is_null: false} },
+      where: { ...where, owner: prev.where?.owner, bp_json: { _is_null: false } },
     }))
   }, [filters, setPagination])
 


### PR DESCRIPTION
### Update BP JSON when the object is not empty

### What does this PR do?

- Resolve #1080 
- Avoid overwriting data with an empty BP JSON.
- Limit loading of BP JSONs to the first 150 producers.

### Steps to test

1. Run the project locally.
2. Go to block producers page.
3. Check that the last producer is rank 150.

![imagen](https://user-images.githubusercontent.com/66583677/204888386-10724f12-5dde-475f-8cc3-1619d783d393.png)

