### PR TITLE
Fix/improvements non compliant rewards 1129

### DIFF
--- a/webapp/src/language/en.json
+++ b/webapp/src/language/en.json
@@ -157,7 +157,7 @@
     "rewards": "Rewards",
     "rewardsPercentage": "Percentage of rewards",
     "viewList": "View full list",
-    "paidProducersText": "in daily rewards"
+    "paidProducersText": "Daily Rewards"
   },
   "nodesRoute": {},
   "nodesDistributionRoute": {},

--- a/webapp/src/language/es.json
+++ b/webapp/src/language/es.json
@@ -163,7 +163,7 @@
     "rewards": "Recompensas",
     "rewardsPercentage": "Porcentaje de recompensas",
     "viewList": "Ver lista completa",
-    "paidProducersText": "en recompensas diarias"
+    "paidProducersText": "Recompensas Diarias"
   },
   "nodesRoute": {},
   "nodesDistributionRoute": {},

--- a/webapp/src/routes/NonCompliantBPs/styles.js
+++ b/webapp/src/routes/NonCompliantBPs/styles.js
@@ -37,15 +37,15 @@ export default (theme) => ({
   bpsContainer: {
     display: 'grid',
     gap: theme.spacing(4, 6),
-    gridTemplateColumns: 'repeat(auto-fit, minmax(800px, auto))',
+    gridTemplateColumns:
+      'repeat(auto-fit, minmax( min( calc( 50% - 100px ), 600px ), auto))',
     margin: '0 40px',
     [theme.breakpoints.down('lg')]: {
       margin: '0',
       gridTemplateColumns: 'repeat(auto-fit, minmax(500px, auto))',
     },
     [theme.breakpoints.down('sm')]: {
-      display: 'flex',
-      flexWrap: 'wrap',
+      gridTemplateColumns: 'repeat(auto-fit, minmax(200px, auto))',
     },
   },
   card: {

--- a/webapp/src/routes/RewardsDistribution/RewardsDistributionStats.js
+++ b/webapp/src/routes/RewardsDistribution/RewardsDistributionStats.js
@@ -136,22 +136,33 @@ const RewardsDistributionStats = ({
                 )}
             </Typography>
             <Typography
-              variant="subtitle1"
+              variant="subtitle2"
               component="p"
               className={classes.textMargin}
             >
-              <TokenToUSD
-                amount={summary?.producersWithoutProperBpJson.rewards}
-                tokenPrice={setting?.token_price}
-              />{' '}
               {t('paidProducersText')}
+            </Typography>
+            <Typography
+              variant="subtitle1"
+              component="p"
+              className={`${classes.textMargin} ${classes.noMargin}`}
+            >
+              {!nodes.length > 0 && (
+                <Skeleton variant="text" width="100%" animation="wave" />
+              )}
+              {nodes.length > 0 && (
+                <TokenToUSD
+                  amount={summary?.producersWithoutProperBpJson.rewards}
+                  tokenPrice={setting?.token_price}
+                />
+              )}
             </Typography>
           </CardContent>
         </Card>
       </div>
       <div className={classes.cardHeader}>
         <Card className={`${classes.cardContent} ${classes.cardShadow}`}>
-          <CardContent className={classes.cards}>
+          <CardContent className={`${classes.cards} ${classes.exchangeCard}`}>
             <div className={classes.center}>
               <Typography
                 variant="subtitle1"

--- a/webapp/src/routes/RewardsDistribution/RewardsDistributionStats.js
+++ b/webapp/src/routes/RewardsDistribution/RewardsDistributionStats.js
@@ -86,8 +86,12 @@ const RewardsDistributionStats = ({
                 </>
               )}
             </Typography>
-            <div className={`${classes.textMargin} ${classes.spaceBetween}`}>
-              <Typography variant="subtitle1" component="p">
+            <div className={`${classes.spaceBetween} ${classes.textBlock}`}>
+              <Typography
+                className={classes.textMargin}
+                variant="subtitle1"
+                component="p"
+              >
                 {!nodes?.length > 0 && (
                   <Skeleton variant="text" width="100%" animation="wave" />
                 )}
@@ -138,14 +142,14 @@ const RewardsDistributionStats = ({
             <Typography
               variant="subtitle2"
               component="p"
-              className={classes.textMargin}
+              className={`${classes.textMargin} ${classes.marginPaidText}`}
             >
               {t('paidProducersText')}
             </Typography>
             <Typography
               variant="subtitle1"
               component="p"
-              className={`${classes.textMargin} ${classes.noMargin}`}
+              className={classes.textMargin}
             >
               {!nodes.length > 0 && (
                 <Skeleton variant="text" width="100%" animation="wave" />
@@ -185,25 +189,29 @@ const RewardsDistributionStats = ({
                 <span className={classes.itemLabel}>{t('highestRewards')}</span>
               </Typography>
             </div>
-            <Typography
-              variant="subtitle1"
-              component="p"
-              className={`${classes.textMargin} ${classes.center}`}
-            >
-              <span className={classes.exchangeRateLabel}>
-                {`${t('exchangeRate')}: `}{' '}
-              </span>
-              {setting?.token_price ? (
-                <span>
-                  {`1 ${eosConfig.tokenSymbol} = $${formatWithThousandSeparator(
-                    setting.token_price,
-                    4,
-                  )}`}
+            <div className={classes.textBlock}>
+              <Typography
+                variant="subtitle1"
+                component="p"
+                className={`${classes.textMargin} ${classes.center}`}
+              >
+                <span className={classes.exchangeRateLabel}>
+                  {`${t('exchangeRate')}: `}{' '}
                 </span>
-              ) : (
-                <span>N/A</span>
-              )}
-            </Typography>
+                {setting?.token_price ? (
+                  <span>
+                    {`1 ${
+                      eosConfig.tokenSymbol
+                    } = $${formatWithThousandSeparator(
+                      setting.token_price,
+                      4,
+                    )}`}
+                  </span>
+                ) : (
+                  <span>N/A</span>
+                )}
+              </Typography>
+            </div>
           </CardContent>
         </Card>
       </div>

--- a/webapp/src/routes/RewardsDistribution/TokenToUSD.js
+++ b/webapp/src/routes/RewardsDistribution/TokenToUSD.js
@@ -8,7 +8,7 @@ const TokenToUSD = ({ amount, tokenPrice }) => {
     <span>
       {`${formatWithThousandSeparator(amount, 2)} ${eosConfig.tokenSymbol}`}
       {tokenPrice &&
-        `/ $${formatWithThousandSeparator(amount * tokenPrice, 2)} USD`}
+        ` / $${formatWithThousandSeparator(amount * tokenPrice, 2)} USD`}
     </span>
   )
 }

--- a/webapp/src/routes/RewardsDistribution/styles.js
+++ b/webapp/src/routes/RewardsDistribution/styles.js
@@ -99,8 +99,14 @@ export default (theme, lowestRewardsColor, highestRewardsColor) => ({
       paddingBottom: theme.spacing(4),
     },
   },
+  exchangeCard: {
+    justifyContent: 'space-around',
+  },
   totalDailyCard: {
     justifyContent: 'flex-start',
+    '& .MuiTypography-h3': {
+      paddingBottom: theme.spacing(2),
+    },
   },
   shadow: {
     '& .MuiPaper-root': {
@@ -121,8 +127,13 @@ export default (theme, lowestRewardsColor, highestRewardsColor) => ({
     height: '24px',
   },
   textMargin: {
-    margin: `${theme.spacing(4, 0, 0)} !important`,
+    margin: `${theme.spacing(3, 0, 0)} !important`,
+    lineHeight: '1 !important',
+    fontWeight: 'normal !important',
     wordBreak: 'break-word',
+  },
+  noMargin: {
+    margin: '0 !important',
   },
   notLocated: {
     display: 'flex',
@@ -130,7 +141,7 @@ export default (theme, lowestRewardsColor, highestRewardsColor) => ({
     justifyContent: 'space-between',
     paddingBottom: theme.spacing(1),
     '& .MuiTypography-h6': {
-      width: 'calc(100% - 130px)',
+      width: 'calc(100% - 125px)',
     },
   },
 })

--- a/webapp/src/routes/RewardsDistribution/styles.js
+++ b/webapp/src/routes/RewardsDistribution/styles.js
@@ -8,6 +8,9 @@ export default (theme, lowestRewardsColor, highestRewardsColor) => ({
     display: 'flex',
     justifyContent: 'center',
   },
+  textBlock: {
+    marginTop: `${theme.spacing(4)} !important`,
+  },
   popoverItem: {
     fontWeight: 'bold',
   },
@@ -75,7 +78,7 @@ export default (theme, lowestRewardsColor, highestRewardsColor) => ({
     [theme.breakpoints.down('lg')]: {
       gridTemplateColumns: 'repeat(2, 1fr)',
     },
-    [theme.breakpoints.down('md')]: {
+    [theme.breakpoints.down('sm')]: {
       display: 'flex',
       flexDirection: 'column',
     },
@@ -127,21 +130,27 @@ export default (theme, lowestRewardsColor, highestRewardsColor) => ({
     height: '24px',
   },
   textMargin: {
-    margin: `${theme.spacing(3, 0, 0)} !important`,
     lineHeight: '1 !important',
     fontWeight: 'normal !important',
     wordBreak: 'break-word',
+    flexWrap: 'wrap',
+    [theme.breakpoints.down('xl')]: {
+      fontSize: '14px !important',
+    },
+    [theme.breakpoints.down('lg')]: {
+      fontSize: '16px !important',
+    },
   },
-  noMargin: {
-    margin: '0 !important',
+  marginPaidText: {
+    padding: theme.spacing(2, 0),
   },
   notLocated: {
     display: 'flex',
     flexWrap: 'wrap',
     justifyContent: 'space-between',
-    paddingBottom: theme.spacing(1),
     '& .MuiTypography-h6': {
       width: 'calc(100% - 125px)',
+      paddingBottom: theme.spacing(2),
     },
   },
 })


### PR DESCRIPTION
### Minor UI improvements in the non-compliant and Rewards Distribution pages

### What does this PR do?

- Resolve #1129
- Fix breakpoints in both pages to avoid wasting space.

### Steps to test

1. Run the project locally.
2. Go to the non-compliant section.
3. Check that for resolutions greater than 1280 px wide the elements are displayed in two or more columns.
4. Go to the rewards distribution page.
5. Check the responsive design.

### Screenshots

## **non-compliant BPs**

### _Desktop design_

![imagen](https://user-images.githubusercontent.com/66583677/214599633-0a9927f1-3cc6-4f57-a163-6642db6b0809.png)
![imagen](https://user-images.githubusercontent.com/66583677/214599667-256b6ab2-3d33-4189-85b8-e7a6f2b84742.png)

### _Mobile design_

![imagen](https://user-images.githubusercontent.com/66583677/214599706-4f8ec1d1-cd63-4263-9cb9-471727463df0.png)

## **Rewards Distribution**

### _Desktop design_

![imagen](https://user-images.githubusercontent.com/66583677/214600274-3739eed7-8528-4ad7-9b87-5635b7958522.png)
![imagen](https://user-images.githubusercontent.com/66583677/214600316-e7a9567f-8a5b-4c55-9cf9-7fdd482dd00d.png)

### _Mobile design_

![imagen](https://user-images.githubusercontent.com/66583677/214600359-a8323edb-db1d-478e-8d09-a0baf2c71a0b.png)
