### PR TITLE
Fix/missing rewards label 1153

### DIFF
--- a/webapp/src/components/NonCompliantCard/index.js
+++ b/webapp/src/components/NonCompliantCard/index.js
@@ -101,7 +101,7 @@ const NonCompliantCard = ({ producer, stats }) => {
         <Typography variant="overline">{t('dailyRewards')}</Typography>
         <RowInfo
           title={`${t('rewards')} (USD)`}
-          value={`$ ${formatWithThousandSeparator(
+          value={`$${formatWithThousandSeparator(
             producer.total_rewards * stats.tokenPrice,
             0,
           )}`}
@@ -113,7 +113,7 @@ const NonCompliantCard = ({ producer, stats }) => {
         <Typography variant="overline">{t('yearlyRewards')}</Typography>
         <RowInfo
           title={`${t('rewards')} (USD)`}
-          value={`$ ${formatWithThousandSeparator(
+          value={`$${formatWithThousandSeparator(
             producer.total_rewards * 365 * stats.tokenPrice,
             0,
           )}`}

--- a/webapp/src/components/NonCompliantCard/index.js
+++ b/webapp/src/components/NonCompliantCard/index.js
@@ -97,9 +97,7 @@ const NonCompliantCard = ({ producer, stats }) => {
           value={`${moment(producer.last_claim_time).format('ll')}`}
         />
       </div>
-      <div
-        className={`${classes.content} ${classes.borderLine} ${classes.hideRewards}`}
-      >
+      <div className={`${classes.content} ${classes.borderLine}`}>
         <Typography variant="overline">{t('dailyRewards')}</Typography>
         <RowInfo
           title={`${t('rewards')} (USD)`}

--- a/webapp/src/components/NonCompliantCard/styles.js
+++ b/webapp/src/components/NonCompliantCard/styles.js
@@ -43,16 +43,9 @@ export default (theme) => ({
       marginLeft: theme.spacing(3),
     },
   },
-  hideRewards: {
-    [theme.breakpoints.down('sm')]: {
-      '& .MuiTypography-overline': {
-        display: 'none',
-      },
-    },
-  },
   lightIcon: {
     '& svg': {
       marginLeft: theme.spacing(2),
     },
-  }
+  },
 })

--- a/webapp/src/language/en.json
+++ b/webapp/src/language/en.json
@@ -149,7 +149,7 @@
   "rewardsDistributionRoute": {
     "dailyRewards": "Total Daily Rewards",
     "yearlyRewards": "Total Yearly Rewards",
-    "topCountryDailyRwards": "Top Country By Daily Rewards",
+    "topCountryDailyRewards": "Top Country By Daily Rewards",
     "notAvailable": "Not available",
     "paidProducers": "Paid BPs Not Located",
     "lowestRewards": "Lowest Rewards",

--- a/webapp/src/language/es.json
+++ b/webapp/src/language/es.json
@@ -155,7 +155,7 @@
   "rewardsDistributionRoute": {
     "dailyRewards": "Recompensas Diarias Totales",
     "yearlyRewards": "Recompensas Anuales Totales",
-    "topCountryDailyRwards": "País Superior Por Recompensas Diarias",
+    "topCountryDailyRewards": "País Superior Por Recompensas Diarias",
     "notAvailable": "No Disponible",
     "paidProducers": "Productores Pagados No Ubicados",
     "lowestRewards": "Recompensas Más Bajas",

--- a/webapp/src/routes/NonCompliantBPs/RewardsStats.js
+++ b/webapp/src/routes/NonCompliantBPs/RewardsStats.js
@@ -19,26 +19,24 @@ const RewardsStats = ({ stats }) => {
     <>
       <div className={`${classes.cardHeader} ${classes.cardShadow}`}>
         <div className={classes.rewardsCards}>
-          <Typography variant="h6" component="h4">
-            {t('paidProducers')}
-          </Typography>
-          <Typography variant="h3" component="p" className={classes.statsText}>
-            {stats.quantity || 0}
-          </Typography>
+          <Typography component="h4">{t('paidProducers')}</Typography>
+          <div className={`${classes.statsText} ${classes.verticallyCenter}`}>
+            <Typography variant="h6" component="p">
+              {stats.quantity || 0}
+            </Typography>
+          </div>
         </div>
       </div>
       <div className={`${classes.cardHeader} ${classes.cardShadow}`}>
         <div className={classes.rewardsCards}>
-          <Typography variant="h6" component="h4">
-            {t('dailyRewards')}
-          </Typography>
-          <div className={classes.statsText}>
-            <Typography variant="h3" component="p" className={classes.price}>
+          <Typography component="h4">{t('dailyRewards')}</Typography>
+          <div className={`${classes.statsText} ${classes.verticallyCenter}`}>
+            <Typography variant="h6" component="p" className={classes.price}>
               {`${formatWithThousandSeparator(stats.dailyRewards, 0)} ${
                 eosConfig.tokenSymbol
               }`}
             </Typography>
-            <Typography variant="h3" component="p" className={classes.price}>
+            <Typography variant="h6" component="p" className={classes.price}>
               {`$${formatWithThousandSeparator(
                 stats.dailyRewards * stats.tokenPrice,
                 0,
@@ -49,16 +47,14 @@ const RewardsStats = ({ stats }) => {
       </div>
       <div className={`${classes.cardHeader} ${classes.cardShadow}`}>
         <div className={classes.rewardsCards}>
-          <Typography variant="h6" component="h4">
-            {t('yearlyRewards')}
-          </Typography>
-          <div className={classes.statsText}>
-            <Typography variant="h3" component="p" className={classes.price}>
+          <Typography component="h4">{t('yearlyRewards')}</Typography>
+          <div className={`${classes.statsText} ${classes.verticallyCenter}`}>
+            <Typography variant="h6" component="p" className={classes.price}>
               {`${formatWithThousandSeparator(stats.yearlyRewards, 0)} ${
                 eosConfig.tokenSymbol
               }`}
             </Typography>
-            <Typography variant="h3" component="p" className={classes.price}>
+            <Typography variant="h6" component="p" className={classes.price}>
               {`$${formatWithThousandSeparator(
                 stats.yearlyRewards * stats.tokenPrice,
                 0,
@@ -69,12 +65,12 @@ const RewardsStats = ({ stats }) => {
       </div>
       <div className={`${classes.cardHeader} ${classes.cardShadow}`}>
         <div className={classes.rewardsCards}>
-          <Typography variant="h6" component="h4">
-            {t('rewardsPercentage')}
-          </Typography>
-          <Typography variant="h3" component="p" className={classes.statsText}>
-            {`${stats.percentageRewards?.toFixed(2)}%`}
-          </Typography>
+          <Typography component="h4">{t('rewardsPercentage')}</Typography>
+          <div className={`${classes.statsText} ${classes.verticallyCenter}`}>
+            <Typography variant="h6" component="p">
+              {`${stats.percentageRewards?.toFixed(2)}%`}
+            </Typography>
+          </div>
         </div>
       </div>
     </>

--- a/webapp/src/routes/NonCompliantBPs/RewardsStats.js
+++ b/webapp/src/routes/NonCompliantBPs/RewardsStats.js
@@ -39,7 +39,7 @@ const RewardsStats = ({ stats }) => {
               }`}
             </Typography>
             <Typography variant="h3" component="p" className={classes.price}>
-              {`$ ${formatWithThousandSeparator(
+              {`$${formatWithThousandSeparator(
                 stats.dailyRewards * stats.tokenPrice,
                 0,
               )} USD`}
@@ -59,7 +59,7 @@ const RewardsStats = ({ stats }) => {
               }`}
             </Typography>
             <Typography variant="h3" component="p" className={classes.price}>
-              {`$ ${formatWithThousandSeparator(
+              {`$${formatWithThousandSeparator(
                 stats.yearlyRewards * stats.tokenPrice,
                 0,
               )} USD`}

--- a/webapp/src/routes/NonCompliantBPs/styles.js
+++ b/webapp/src/routes/NonCompliantBPs/styles.js
@@ -26,6 +26,9 @@ export default (theme) => ({
     height: '100%',
     minHeight: '125px',
     padding: theme.spacing(4),
+    '& h4': {
+      fontWeight: 'bold',
+    },
   },
   verticallyCenter: {
     height: '80%',

--- a/webapp/src/routes/NonCompliantBPs/styles.js
+++ b/webapp/src/routes/NonCompliantBPs/styles.js
@@ -4,7 +4,6 @@ export default (theme) => ({
   },
   statsText: {
     textAlign: 'center',
-    marginTop: `${theme.spacing(4)} !important`,
   },
   price: {
     paddingBottom: theme.spacing(2),
@@ -13,7 +12,7 @@ export default (theme) => ({
     display: 'flex',
     flexFlow: 'row nowrap',
     gap: theme.spacing(6),
-    margin: `${theme.spacing(6)} 40px ${theme.spacing(4)}`,
+    margin: `${theme.spacing(6)} 24px ${theme.spacing(4)}`,
     paddingBottom: theme.spacing(4),
     borderBottom: '1px solid #e0e0e0',
     [theme.breakpoints.down('lg')]: {
@@ -24,8 +23,15 @@ export default (theme) => ({
     },
   },
   rewardsCards: {
+    height: '100%',
     minHeight: '125px',
     padding: theme.spacing(4),
+  },
+  verticallyCenter: {
+    height: '80%',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
   },
   cardHeader: {
     width: '100px',
@@ -42,7 +48,7 @@ export default (theme) => ({
     gap: theme.spacing(4, 6),
     gridTemplateColumns:
       'repeat(auto-fit, minmax( min( calc( 50% - 100px ), 600px ), auto))',
-    margin: '0 40px',
+    margin: '0 24px',
     [theme.breakpoints.down('lg')]: {
       margin: '0',
       gridTemplateColumns: 'repeat(auto-fit, minmax(500px, auto))',

--- a/webapp/src/routes/RewardsDistribution/RewardsDistributionStats.js
+++ b/webapp/src/routes/RewardsDistribution/RewardsDistributionStats.js
@@ -32,45 +32,45 @@ const RewardsDistributionStats = ({ summary, setting, handlePopoverOpen }) => {
       <div className={classes.cardHeader}>
         <Card className={`${classes.cardContent} ${classes.cardShadow}`}>
           <CardContent className={`${classes.cards} ${classes.totalDailyCard}`}>
-            <Typography variant="h6" component="h4">
-              {t('dailyRewards')}
-            </Typography>
-            <Typography variant="h3" component="p">
-              {!summary?.dailyRewards > 0 && (
-                <Skeleton variant="text" width="100%" animation="wave" />
-              )}
-              {summary?.dailyRewards > 0 && (
-                <span>
-                  {formatWithThousandSeparator(summary.dailyRewards, 2)}{' '}
-                  {eosConfig.tokenSymbol}
-                </span>
-              )}
-            </Typography>
-            <Typography variant="h3" component="p">
-              {!setting?.token_price > 0 && (
-                <Skeleton variant="text" width="100%" animation="wave" />
-              )}
-              {setting?.token_price && !!summary?.dailyRewards && (
-                <span>
-                  $
-                  {formatWithThousandSeparator(
-                    summary.dailyRewards * setting?.token_price,
-                    0,
-                  )}{' '}
-                  USD
-                </span>
-              )}
-            </Typography>
+            <Typography component="h4">{t('dailyRewards')}</Typography>
+            <div className={classes.verticallyCenter}>
+              <Typography variant="h6" component="p">
+                {!summary?.dailyRewards > 0 && (
+                  <Skeleton variant="text" width="100%" animation="wave" />
+                )}
+                {summary?.dailyRewards > 0 && (
+                  <span>
+                    {formatWithThousandSeparator(summary.dailyRewards, 2)}{' '}
+                    {eosConfig.tokenSymbol}
+                  </span>
+                )}
+              </Typography>
+              <Typography variant="h6" component="p">
+                {!setting?.token_price > 0 && (
+                  <Skeleton variant="text" width="100%" animation="wave" />
+                )}
+                {setting?.token_price && !!summary?.dailyRewards && (
+                  <span>
+                    $
+                    {formatWithThousandSeparator(
+                      summary.dailyRewards * setting?.token_price,
+                      0,
+                    )}{' '}
+                    USD
+                  </span>
+                )}
+              </Typography>
+            </div>
           </CardContent>
         </Card>
       </div>
       <div className={classes.cardHeader}>
         <Card className={`${classes.cardContent} ${classes.cardShadow}`}>
           <CardContent className={classes.cards}>
-            <Typography variant="h6" component="h4">
-              {t('topCountryDailyRwards')}
+            <Typography component="h4">
+              {t('topCountryDailyRewards')}
             </Typography>
-            <Typography variant="h3" component="p">
+            <Typography variant="h6" component="p">
               {!summary?.topCountryByRewards > 0 && (
                 <Skeleton variant="text" width="100%" animation="wave" />
               )}
@@ -109,9 +109,7 @@ const RewardsDistributionStats = ({ summary, setting, handlePopoverOpen }) => {
         <Card className={`${classes.cardContent} ${classes.cardShadow}`}>
           <CardContent className={classes.cards}>
             <div className={classes.notLocated}>
-              <Typography variant="h6" component="h4">
-                {t('paidProducers')}
-              </Typography>
+              <Typography component="h4">{t('paidProducers')}</Typography>
               {!!summary?.producersWithoutProperBpJson.quantity && (
                 <Button
                   className={classes.nonCompliantButton}
@@ -125,7 +123,7 @@ const RewardsDistributionStats = ({ summary, setting, handlePopoverOpen }) => {
                 </Button>
               )}
             </div>
-            <Typography variant="h3" component="p">
+            <Typography variant="h6" component="p">
               {!summary?.producersWithoutProperBpJson.quantity > 0 ?? (
                 <Skeleton variant="text" width="100%" animation="wave" />
               )}

--- a/webapp/src/routes/RewardsDistribution/styles.js
+++ b/webapp/src/routes/RewardsDistribution/styles.js
@@ -103,9 +103,8 @@ export default (theme, lowestRewardsColor, highestRewardsColor) => ({
     display: 'flex',
     flexDirection: 'column',
     justifyContent: 'space-between',
-    '& .MuiTypography-h4': {
-      display: 'flex',
-      paddingBottom: theme.spacing(4),
+    '& h4': {
+      fontWeight: 'bold'
     },
   },
   exchangeCard: {
@@ -154,7 +153,7 @@ export default (theme, lowestRewardsColor, highestRewardsColor) => ({
     display: 'flex',
     flexWrap: 'wrap',
     justifyContent: 'space-between',
-    '& .MuiTypography-h4': {
+    '& h4': {
       width: 'calc(100% - 125px)',
       paddingBottom: theme.spacing(2),
     },

--- a/webapp/src/routes/RewardsDistribution/styles.js
+++ b/webapp/src/routes/RewardsDistribution/styles.js
@@ -8,6 +8,12 @@ export default (theme, lowestRewardsColor, highestRewardsColor) => ({
     display: 'flex',
     justifyContent: 'center',
   },
+  verticallyCenter: {
+    height: '80%',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+  },
   textBlock: {
     marginTop: `${theme.spacing(4)} !important`,
   },
@@ -97,7 +103,7 @@ export default (theme, lowestRewardsColor, highestRewardsColor) => ({
     display: 'flex',
     flexDirection: 'column',
     justifyContent: 'space-between',
-    '& .MuiTypography-h6': {
+    '& .MuiTypography-h4': {
       display: 'flex',
       paddingBottom: theme.spacing(4),
     },
@@ -107,7 +113,7 @@ export default (theme, lowestRewardsColor, highestRewardsColor) => ({
   },
   totalDailyCard: {
     justifyContent: 'flex-start',
-    '& .MuiTypography-h3': {
+    '& .MuiTypography-h6': {
       paddingBottom: theme.spacing(2),
     },
   },
@@ -148,7 +154,7 @@ export default (theme, lowestRewardsColor, highestRewardsColor) => ({
     display: 'flex',
     flexWrap: 'wrap',
     justifyContent: 'space-between',
-    '& .MuiTypography-h6': {
+    '& .MuiTypography-h4': {
       width: 'calc(100% - 125px)',
       paddingBottom: theme.spacing(2),
     },


### PR DESCRIPTION
### Missing labels on mobile view and change design to keep consistency

### What does this PR do?

- Resolve #1153
- Resolve #1154 
- Set the right margin between the sidebar and the cards of the undiscoverable bps page

### Steps to test

1. Run the project locally
2. Go to Undiscoverable bps page and Rewards Distribution page
3. Check the styles of the titles in the cards
4. In undiscoverable bps check the mobile version

### Screenshots

#### Rewards Distribution
![imagen](https://user-images.githubusercontent.com/66583677/219703723-acfea50b-5d30-42e8-8683-aa95d3e61019.png)

#### Undiscoverable bps
![imagen](https://user-images.githubusercontent.com/66583677/219703842-963dd2a9-5500-4987-94d1-50a2ead4e9e5.png)

*Show rewards labels in the mobile design*
![imagen](https://user-images.githubusercontent.com/66583677/219703869-86de56c2-a3f9-4433-9330-beab5f92d828.png)

