### PR TITLE
Fix/rate limit 1157

### DIFF
--- a/.github/workflows/deploy-ultra-testnet.yaml
+++ b/.github/workflows/deploy-ultra-testnet.yaml
@@ -45,7 +45,7 @@ jobs:
           REACT_APP_EOS_API_NETWORK_NAME: 'ultra-testnet'
           REACT_APP_EOS_API_NETWORK_LABEL: 'Ultra Testnet'
           REACT_APP_EOS_API_NETWORK_LOGO: 'https://icodrops.com/wp-content/uploads/2019/06/Ultra-150x150.jpg'
-          REACT_APP_EOS_API_HOSTS: '[\"ultratest.api.eosnation.io\"]'
+          REACT_APP_EOS_API_HOSTS: '[\"ultratest.api.eosnation.io\",\"testnet.ultra.eosrio.io\",\"api.testnet.ultra.eossweden.org\",\"ultratest-api.eoseoul.io\"]'
           REACT_APP_EOS_API_PORT: '443'
           REACT_APP_EOS_API_PROTOCOL: 'https'
           REACT_APP_EOS_CHAIN_ID: '7fc56be645bb76ab9d747b53089f132dcb7681db06f0852cfa03eaf6f7ac80e9'
@@ -80,7 +80,7 @@ jobs:
           POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
           POSTGRES_DATA: ${{ secrets.POSTGRES_DATA }}
           # hapi
-          HAPI_EOS_API_ENDPOINTS: '["https://ultratest.api.eosnation.io"]'
+          HAPI_EOS_API_ENDPOINTS: '["http://ultratest.api.eosnation.io","https://testnet.ultra.eosrio.io","https://api.testnet.ultra.eossweden.org","https://ultratest-api.eoseoul.io"]'
           HAPI_EOS_API_NETWORK_NAME: ultra-testnet
           HAPI_EOS_API_CHAIN_ID: 7fc56be645bb76ab9d747b53089f132dcb7681db06f0852cfa03eaf6f7ac80e9
           HAPI_EOS_BASE_ACCOUNT: ${{ secrets.HAPI_EOS_BASE_ACCOUNT }}


### PR DESCRIPTION
### Decrease the number of requests in the main page.

### What does this PR do?

- Resolve #1157
- Fix error that ignores the given interval and requests the information of a block more times than necessary.
- When all endpoints fail, it stops requesting data and waits 30 seconds until an endpoint responds.
- Add ultra testnet endpoints to avoid data loss.

### Steps to test

1. Run the project locally.
1. Go to the main page.
1. Check the graph of transactions per seconds.

### Screenshots

An example of how many requests were made to get block data
![imagen](https://user-images.githubusercontent.com/66583677/220776972-932289ce-ae65-44a0-8cc7-49b23b62a35e.png)

Now the number will be lower
![imagen](https://user-images.githubusercontent.com/66583677/220777418-1f64644c-01c0-4f6f-a543-2532352e5ac1.png)

