### PR TITLE
fix(webapp): Endpoints fail in Account and Contracts page

### DIFF
--- a/webapp/src/context/state.context.js
+++ b/webapp/src/context/state.context.js
@@ -195,7 +195,7 @@ export const useSharedState = () => {
         },
       })
     } catch (error) {
-      console.error(error)
+      console.error(error?.message || error)
     }
   }, [dispatch, state.tpb, state.tps, state.tpsWaitingBlock])
 
@@ -218,7 +218,7 @@ export const useSharedState = () => {
 
         dispatch({ type: 'updateSchedule', payload: result.active })
       } catch (error) {
-        console.error(error)
+        console.error(error?.message || error)
 
         if (error?.message === ENDPOINTS_ERROR) {
           await stopTrackingProducerSchedule()
@@ -250,7 +250,7 @@ export const useSharedState = () => {
 
         setLastBlock(info.head_block_num)
       } catch (error) {
-        console.error(error)
+        console.error(error?.message || error)
 
         if (error?.message === ENDPOINTS_ERROR) {
           await stopTrackingInfo()

--- a/webapp/src/utils/eosapi.js
+++ b/webapp/src/utils/eosapi.js
@@ -6,7 +6,7 @@ export const ENDPOINTS_ERROR =
   'Each endpoint failed when trying to execute the function'
 
 const waitRequestInterval = 120000
-const timeout = 15000
+const timeout = 60000
 const eosApis = eosConfig.endpoints.map(endpoint => {
   return {
     api: EosApi({
@@ -61,11 +61,16 @@ const callWithTimeout = async (promise, ms) => {
     timeoutID = setTimeout(() => reject(new Error(timeoutMessage)), ms)
   })
 
-  return Promise.race([promise, timeoutPromise]).then((response) => {
-    clearTimeout(timeoutID)
-
-    return response
-  })
+  return Promise.race([promise, timeoutPromise])
+    .then(response => {
+      return response
+    })
+    .catch(error => {
+      throw error
+    })
+    .finally(() => {
+      clearTimeout(timeoutID)
+    })
 }
 
 const getAbi = async account => {

--- a/webapp/src/utils/eosapi.js
+++ b/webapp/src/utils/eosapi.js
@@ -62,9 +62,7 @@ const callWithTimeout = async (promise, ms) => {
   })
 
   return Promise.race([promise, timeoutPromise])
-    .then(response => {
-      return response
-    })
+    .then(response => response)
     .catch(error => {
       throw error
     })


### PR DESCRIPTION
### Clear timeoutID and increase timeout

### What does this PR do?

- Resolve #1164
- Clear the timeout id when the promise ends.
- Increase the timeout.

### Steps to test

1. Run the project locally.
2. Go to "Account and Contracts" page.
3. Check that the error doesn't appear. 
