### PR TITLE
Fix/health check false negative 1170

### DIFF
--- a/.env.proton
+++ b/.env.proton
@@ -20,7 +20,7 @@ HASURA_GRAPHQL_ACTION_BASE_URL=http://hapi:9090
 
 # hapi
 HAPI_EOS_API_NETWORK_NAME=proton
-HAPI_EOS_API_ENDPOINTS=["https://proton.edenia.cloud","https://proton.greymass.com","https://proton.eosphere.io"]
+HAPI_EOS_API_ENDPOINTS=["https://proton.edenia.cloud","https://proton.eosusa.io","https://proton.greymass.com","https://proton.eosargentina.io"]
 HAPI_EOS_API_CHAIN_ID=384da888112027f0321850a169f737c33e53b388aad48b5adace4bab97f437e0
 HAPI_EOS_BASE_ACCOUNT=baseaccount
 HAPI_EOS_BASE_ACCOUNT_PASSWORD=PW...
@@ -70,7 +70,7 @@ REACT_APP_HASURA_URL=http://localhost:8080/v1/graphql
 REACT_APP_EOS_API_NETWORK_NAME=proton
 REACT_APP_EOS_API_NETWORK_LABEL=Proton
 REACT_APP_EOS_API_NETWORK_LOGO=https://antelope.tools/images/proton.png
-REACT_APP_EOS_API_HOSTS=["proton.edenia.cloud","proton.greymass.com","proton.eosphere.io"]
+REACT_APP_EOS_API_HOSTS=["proton.edenia.cloud","proton.eosusa.io","proton.greymass.com","proton.eosargentina.io"]
 REACT_APP_EOS_API_PORT=443
 REACT_APP_EOS_API_PROTOCOL=https
 REACT_APP_EOS_CHAIN_ID=384da888112027f0321850a169f737c33e53b388aad48b5adace4bab97f437e0

--- a/.env.protontestnet
+++ b/.env.protontestnet
@@ -20,7 +20,7 @@ HASURA_GRAPHQL_ACTION_BASE_URL=http://hapi:9090
 
 # hapi
 HAPI_EOS_API_NETWORK_NAME=proton
-HAPI_EOS_API_ENDPOINTS=["https://proton-testnet.edenia.cloud","https://test.proton.eosusa.news","https://proton-testnet.eosphere.io","https://api.protontest.alohaeos.com"]
+HAPI_EOS_API_ENDPOINTS=["https://proton-testnet.edenia.cloud","https://test.proton.eosusa.news","https://api.testnet.totalproton.tech","https://tn1.protonnz.com"]
 HAPI_EOS_API_CHAIN_ID=71ee83bcf52142d61019d95f9cc5427ba6a0d7ff8accd9e2088ae2abeaf3d3dd
 HAPI_EOS_BASE_ACCOUNT=baseaccount
 HAPI_EOS_BASE_ACCOUNT_PASSWORD=PW...
@@ -69,7 +69,7 @@ REACT_APP_HASURA_URL=http://localhost:8080/v1/graphql
 REACT_APP_EOS_API_NETWORK_NAME=proton-testnet
 REACT_APP_EOS_API_NETWORK_LABEL=Proton Testnet
 REACT_APP_EOS_API_NETWORK_LOGO=https://antelope.tools/images/proton.png
-REACT_APP_EOS_API_HOSTS=["test.proton.eosusa.news","proton-testnet.edenia.cloud","proton-testnet.eosphere.io","api.protontest.alohaeos.com"]
+REACT_APP_EOS_API_HOSTS=["test.proton.eosusa.news","proton-testnet.edenia.cloud","api.testnet.totalproton.tech","tn1.protonnz.com"]
 REACT_APP_EOS_API_PORT=443
 REACT_APP_EOS_API_PROTOCOL=https
 REACT_APP_EOS_CHAIN_ID=71ee83bcf52142d61019d95f9cc5427ba6a0d7ff8accd9e2088ae2abeaf3d3dd

--- a/.env.telostestnet
+++ b/.env.telostestnet
@@ -20,7 +20,7 @@ HASURA_GRAPHQL_ACTION_BASE_URL=http://hapi:9090
 
 # hapi
 HAPI_EOS_API_NETWORK_NAME=telos
-HAPI_EOS_API_ENDPOINTS=["https://testnet.telos.caleos.io","https://telos-testnet.eosphere.io","https://testnet.telosusa.io"]
+HAPI_EOS_API_ENDPOINTS=["https://testnet.telos.caleos.io","https://telos-testnet.eosphere.io","https://telostest.api.eosnation.io"]
 HAPI_EOS_API_CHAIN_ID=1eaa0824707c8c16bd25145493bf062aecddfeb56c736f6ba6397f3195f33c9f
 HAPI_EOS_BASE_ACCOUNT=eosmechatero
 HAPI_EOS_BASE_ACCOUNT_PASSWORD=PW...
@@ -70,7 +70,7 @@ REACT_APP_HASURA_URL=http://localhost:8080/v1/graphql
 REACT_APP_EOS_API_NETWORK_NAME=telos-testnet
 REACT_APP_EOS_API_NETWORK_LABEL=Telos Testnet
 REACT_APP_EOS_API_NETWORK_LOGO=https://antelope.tools/images/telos.png
-REACT_APP_EOS_API_HOSTS=["testnet.telos.caleos.io","telos-testnet.eosphere.io","testnet.telosusa.io"]
+REACT_APP_EOS_API_HOSTS=["testnet.telos.caleos.io","telos-testnet.eosphere.io","telostest.api.eosnation.io"]
 REACT_APP_EOS_API_PORT=443
 REACT_APP_EOS_API_PROTOCOL=https
 REACT_APP_EOS_CHAIN_ID=1eaa0824707c8c16bd25145493bf062aecddfeb56c736f6ba6397f3195f33c9f

--- a/.env.wax
+++ b/.env.wax
@@ -20,7 +20,7 @@ HASURA_GRAPHQL_ACTION_BASE_URL=http://hapi:9090
 
 # hapi
 HAPI_EOS_API_NETWORK_NAME=wax
-HAPI_EOS_API_ENDPOINTS=["https://wax.eosn.io","https://wax.edenia.cloud","https://wax.api.eosnation.io","https://wax.greymass.com"]
+HAPI_EOS_API_ENDPOINTS=["https://wax.api.eosnation.io","https://wax.edenia.cloud","https://wax.api.eosnation.io","https://wax.greymass.com"]
 HAPI_EOS_API_CHAIN_ID=1064487b3cd1a897ce03ae5b6a865651747e2e152090f99c1d19d44e01aea5a4
 HAPI_EOS_BASE_ACCOUNT=baseaccount
 HAPI_EOS_BASE_ACCOUNT_PASSWORD=PW...
@@ -73,7 +73,7 @@ REACT_APP_HASURA_URL=http://localhost:8080/v1/graphql
 REACT_APP_EOS_API_NETWORK_NAME=wax-mainnet
 REACT_APP_EOS_API_NETWORK_LABEL=WAX Mainnet
 REACT_APP_EOS_API_NETWORK_LOGO=https://antelope.tools/images/wax.jpg
-REACT_APP_EOS_API_HOSTS=["wax.eosn.io","wax.edenia.cloud","wax.api.eosnation.io","wax.greymass.com"]
+REACT_APP_EOS_API_HOSTS=["wax.api.eosnation.io","wax.edenia.cloud","wax.api.eosnation.io","wax.greymass.com"]
 REACT_APP_EOS_API_PORT=443
 REACT_APP_EOS_API_PROTOCOL=https
 REACT_APP_EOS_CHAIN_ID=1064487b3cd1a897ce03ae5b6a865651747e2e152090f99c1d19d44e01aea5a4

--- a/.github/workflows/deploy-proton-testnet.yaml
+++ b/.github/workflows/deploy-proton-testnet.yaml
@@ -45,7 +45,7 @@ jobs:
           REACT_APP_EOS_API_NETWORK_NAME: 'proton-testnet'
           REACT_APP_EOS_API_NETWORK_LABEL: 'Proton Testnet'
           REACT_APP_EOS_API_NETWORK_LOGO: 'https://antelope.tools/images/proton.png'
-          REACT_APP_EOS_API_HOSTS: '[\"test.proton.eosusa.io\",\"proton-testnet.edenia.cloud\",\"proton-testnet.eosphere.io\",\"api.protontest.alohaeos.com\"]'
+          REACT_APP_EOS_API_HOSTS: '[\"test.proton.eosusa.io\",\"proton-testnet.edenia.cloud\",\"api.testnet.totalproton.tech\",\"tn1.protonnz.com\"]'
           REACT_APP_EOS_API_PORT: '443'
           REACT_APP_EOS_API_PROTOCOL: 'https'
           REACT_APP_EOS_CHAIN_ID: '71ee83bcf52142d61019d95f9cc5427ba6a0d7ff8accd9e2088ae2abeaf3d3dd'
@@ -80,7 +80,7 @@ jobs:
           POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
           POSTGRES_DATA: ${{ secrets.POSTGRES_DATA }}
           # hapi
-          HAPI_EOS_API_ENDPOINTS: '["https://proton-testnet.edenia.cloud","https://test.proton.eosusa.io","https://proton-testnet.eosphere.io","https://api.protontest.alohaeos.com"]'
+          HAPI_EOS_API_ENDPOINTS: '["https://proton-testnet.edenia.cloud","https://test.proton.eosusa.io","https://api.testnet.totalproton.tech","https://tn1.protonnz.com"]'
           HAPI_EOS_API_CHAIN_ID: 71ee83bcf52142d61019d95f9cc5427ba6a0d7ff8accd9e2088ae2abeaf3d3dd
           HAPI_EOS_BASE_ACCOUNT: ${{ secrets.HAPI_EOS_BASE_ACCOUNT }}
           HAPI_EOS_BASE_ACCOUNT_PASSWORD: ${{ secrets.HAPI_EOS_BASE_ACCOUNT_PASSWORD }}

--- a/.github/workflows/deploy-proton.yaml
+++ b/.github/workflows/deploy-proton.yaml
@@ -45,7 +45,7 @@ jobs:
           REACT_APP_EOS_API_NETWORK_NAME: 'proton'
           REACT_APP_EOS_API_NETWORK_LABEL: 'Proton Mainnet'
           REACT_APP_EOS_API_NETWORK_LOGO: 'https://antelope.tools/images/proton.png'
-          REACT_APP_EOS_API_HOSTS: '[\"proton.edenia.cloud\",\"proton.eosusa.io\",\"proton.greymass.com\",\"proton.eosphere.io\"]'
+          REACT_APP_EOS_API_HOSTS: '[\"proton.edenia.cloud\",\"proton.eosusa.io\",\"proton.greymass.com\",\"proton.eosargentina.io\"]'
           REACT_APP_EOS_API_PORT: '443'
           REACT_APP_EOS_API_PROTOCOL: 'https'
           REACT_APP_EOS_CHAIN_ID: '384da888112027f0321850a169f737c33e53b388aad48b5adace4bab97f437e0'
@@ -80,7 +80,7 @@ jobs:
           POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
           POSTGRES_DATA: ${{ secrets.POSTGRES_DATA }}
           # hapi
-          HAPI_EOS_API_ENDPOINTS: '["https://proton.edenia.cloud","https://proton.eosusa.news","https://proton.greymass.com","https://proton.eosphere.io"]'
+          HAPI_EOS_API_ENDPOINTS: '["https://proton.edenia.cloud","https://proton.eosusa.io","https://proton.greymass.com","https://proton.eosargentina.io"]'
           HAPI_EOS_API_CHAIN_ID: 384da888112027f0321850a169f737c33e53b388aad48b5adace4bab97f437e0
           HAPI_EOS_BASE_ACCOUNT: ${{ secrets.HAPI_EOS_BASE_ACCOUNT }}
           HAPI_EOS_BASE_ACCOUNT_PASSWORD: ${{ secrets.HAPI_EOS_BASE_ACCOUNT_PASSWORD }}

--- a/.github/workflows/deploy-telos-testnet.yaml
+++ b/.github/workflows/deploy-telos-testnet.yaml
@@ -45,7 +45,7 @@ jobs:
           REACT_APP_EOS_API_NETWORK_NAME: 'telos-testnet'
           REACT_APP_EOS_API_NETWORK_LABEL: 'Telos Testnet'
           REACT_APP_EOS_API_NETWORK_LOGO: 'https://antelope.tools/images/telos.png'
-          REACT_APP_EOS_API_HOSTS: '[\"testnet.telos.caleos.io\",\"telos-testnet.eosphere.io\",\"testnet.telosusa.io\"]'
+          REACT_APP_EOS_API_HOSTS: '[\"testnet.telos.caleos.io\",\"telos-testnet.eosphere.io\",\"telostest.api.eosnation.io\"]'
           REACT_APP_EOS_API_PORT: '443'
           REACT_APP_EOS_API_PROTOCOL: 'https'
           REACT_APP_EOS_CHAIN_ID: '1eaa0824707c8c16bd25145493bf062aecddfeb56c736f6ba6397f3195f33c9f'
@@ -81,7 +81,7 @@ jobs:
           POSTGRES_DATA: ${{ secrets.POSTGRES_DATA }}
           # hapi
           HAPI_EOS_API_NETWORK_NAME: telos
-          HAPI_EOS_API_ENDPOINTS: '["https://testnet.telos.caleos.io","https://telos-testnet.eosphere.io","https://testnet.telosusa.io"]'
+          HAPI_EOS_API_ENDPOINTS: '["https://testnet.telos.caleos.io","https://telos-testnet.eosphere.io","https://telostest.api.eosnation.io"]'
           HAPI_EOS_API_CHAIN_ID: 1eaa0824707c8c16bd25145493bf062aecddfeb56c736f6ba6397f3195f33c9f
           HAPI_EOS_BASE_ACCOUNT: ${{ secrets.HAPI_EOS_BASE_ACCOUNT }}
           HAPI_EOS_BASE_ACCOUNT_PASSWORD: ${{ secrets.HAPI_EOS_BASE_ACCOUNT_PASSWORD }}

--- a/.github/workflows/deploy-wax.yaml
+++ b/.github/workflows/deploy-wax.yaml
@@ -45,7 +45,7 @@ jobs:
           REACT_APP_EOS_API_NETWORK_NAME: 'wax'
           REACT_APP_EOS_API_NETWORK_LABEL: 'WAX Mainnet'
           REACT_APP_EOS_API_NETWORK_LOGO: 'https://antelope.tools/images/wax.jpg'
-          REACT_APP_EOS_API_HOSTS: '[\"wax.eosn.io\",\"wax.edenia.cloud\",\"wax.api.eosnation.io\",\"wax.greymass.com\"]'
+          REACT_APP_EOS_API_HOSTS: '[\"wax.api.eosnation.io\",\"wax.edenia.cloud\",\"wax.api.eosnation.io\",\"wax.greymass.com\"]'
           REACT_APP_EOS_API_PORT: '443'
           REACT_APP_EOS_API_PROTOCOL: 'https'
           REACT_APP_EOS_CHAIN_ID: '1064487b3cd1a897ce03ae5b6a865651747e2e152090f99c1d19d44e01aea5a4'
@@ -81,7 +81,7 @@ jobs:
           POSTGRES_DATA: ${{ secrets.POSTGRES_DATA }}
           # hapi
           HAPI_EOS_API_NETWORK_NAME: wax
-          HAPI_EOS_API_ENDPOINTS: '["https://wax.eosn.io","https://wax.edenia.cloud","https://wax.api.eosnation.io","https://wax.greymass.com"]'
+          HAPI_EOS_API_ENDPOINTS: '["https://wax.api.eosnation.io","https://wax.edenia.cloud","https://wax.api.eosnation.io","https://wax.greymass.com"]'
           HAPI_EOS_API_CHAIN_ID: 1064487b3cd1a897ce03ae5b6a865651747e2e152090f99c1d19d44e01aea5a4
           HAPI_EOS_BASE_ACCOUNT: ${{ secrets.HAPI_EOS_BASE_ACCOUNT }}
           HAPI_EOS_BASE_ACCOUNT_PASSWORD: ${{ secrets.HAPI_EOS_BASE_ACCOUNT_PASSWORD }}

--- a/hapi/src/config/eos.config.js
+++ b/hapi/src/config/eos.config.js
@@ -45,6 +45,12 @@ module.exports = {
     telos: 'telos',
     wax: 'wax'
   },
+  healthCheckAPIs: [
+    { name: 'chain-api', api: '/v1/chain/get_info' },
+    { name: 'atomic-assets-api', api: '/atomicassets/v1/config' },
+    { name: 'hyperion-v2', api: '/v2/health' },
+    { name: 'light-api', api: '/api/status' }
+  ],
   rewardsToken: process.env.HAPI_REWARDS_TOKEN,
   eosRateUrl: process.env.HAPI_EOSRATE_GET_STATS_URL,
   eosRateUser: process.env.HAPI_EOSRATE_GET_STATS_USER,

--- a/hapi/src/utils/producer.util.js
+++ b/hapi/src/utils/producer.util.js
@@ -31,7 +31,7 @@ const getSupportedAPIs = async (api) => {
 
   try {
     const response = await axiosUtil.instance.get(
-      `${api}/v1/node/get_supported_apis`
+      `${api}/v1/node/get_supported_apis`, { timeout: 30000 }
     )
 
     supportedAPIs = response.data?.apis

--- a/hapi/src/utils/producer.util.js
+++ b/hapi/src/utils/producer.util.js
@@ -8,7 +8,7 @@ const getUrlStatus = async (url, api = '') => {
   url = url.replace(urlRegex, '')
 
   try {
-    const response = await axiosUtil.instance.get(`${url}${api}`)
+    const response = await axiosUtil.instance.get(`${url}${api}`, { timeout: 30000 })
 
     return response
   } catch (error) {

--- a/hapi/src/utils/producer.util.js
+++ b/hapi/src/utils/producer.util.js
@@ -4,6 +4,9 @@ const hasuraUtil = require('./hasura.util')
 const { eosConfig } = require('../config')
 
 const getUrlStatus = async (url, api = '') => {
+  const urlRegex = /\/$/
+  url = url.replace(urlRegex, '')
+
   try {
     const response = await axiosUtil.instance.get(`${url}${api}`)
 
@@ -13,8 +16,8 @@ const getUrlStatus = async (url, api = '') => {
   }
 }
 
-const getNodeInfo = async url => {
-  const response = await getUrlStatus(url, '/v1/chain/get_info')
+const getNodeInfo = async (url, api = '/v1/chain/get_info') => {
+  const response = await getUrlStatus(url, api)
 
   return {
     ...(response?.data && { nodeInfo: response.data }),

--- a/webapp/src/components/EndpointsTable/index.js
+++ b/webapp/src/components/EndpointsTable/index.js
@@ -46,7 +46,7 @@ const EndpointsTable = ({ producers }) => {
     const diffBlockTimems =
       new Date(endpoint.updated_at) - new Date(endpoint.head_block_time)
 
-    return diffBlockTimems <= syncToleranceInterval || !endpoint.head_block_time
+    return diffBlockTimems <= syncToleranceInterval
   }
 
   const getStatus = endpoint => {
@@ -54,7 +54,9 @@ const EndpointsTable = ({ producers }) => {
 
     switch (Math.floor(endpoint.response?.status / 100)) {
       case 2:
-        return isSynchronized(endpoint) ? 'greenLight' : 'timerOff'
+        return !endpoint.head_block_time || isSynchronized(endpoint)
+          ? 'greenLight'
+          : 'timerOff'
       case 4:
       case 5:
         return 'yellowLight'

--- a/webapp/src/components/EndpointsTable/index.js
+++ b/webapp/src/components/EndpointsTable/index.js
@@ -46,7 +46,7 @@ const EndpointsTable = ({ producers }) => {
     const diffBlockTimems =
       new Date(endpoint.updated_at) - new Date(endpoint.head_block_time)
 
-    return diffBlockTimems <= syncToleranceInterval
+    return diffBlockTimems <= syncToleranceInterval || !endpoint.head_block_time
   }
 
   const getStatus = endpoint => {

--- a/webapp/src/components/EndpointsTable/index.js
+++ b/webapp/src/components/EndpointsTable/index.js
@@ -13,7 +13,7 @@ import { Tooltip as MUITooltip } from '@mui/material'
 import ListAltIcon from '@mui/icons-material/ListAlt'
 import { Link as RouterLink } from 'react-router-dom'
 import Link from '@mui/material/Link'
-import QueryStatsIcon from '@mui/icons-material/QueryStats';
+import QueryStatsIcon from '@mui/icons-material/QueryStats'
 
 import HealthCheck from '../HealthCheck'
 import HealthCheckInfo from 'components/HealthCheck/HealthCheckInfo'
@@ -42,24 +42,24 @@ const EndpointsTable = ({ producers }) => {
 
   const syncToleranceInterval = eosConfig.syncToleranceInterval
 
-  const getStatus = (endpoint) => {
-    if (endpoint.response.status === undefined) return
-
+  const isSynchronized = endpoint => {
     const diffBlockTimems =
       new Date(endpoint.updated_at) - new Date(endpoint.head_block_time)
 
-    if (diffBlockTimems <= syncToleranceInterval) {
-      return 'greenLight'
-    } else {
-      switch (Math.floor(endpoint.response?.status / 100)) {
-        case 2:
-          return 'timerOff'
-        case 4:
-        case 5:
-          return 'yellowLight'
-        default:
-          return 'redLight'
-      }
+    return diffBlockTimems <= syncToleranceInterval
+  }
+
+  const getStatus = endpoint => {
+    if (endpoint.response.status === undefined) return
+
+    switch (Math.floor(endpoint.response?.status / 100)) {
+      case 2:
+        return isSynchronized(endpoint) ? 'greenLight' : 'timerOff'
+      case 4:
+      case 5:
+        return 'yellowLight'
+      default:
+        return 'redLight'
     }
   }
 
@@ -144,19 +144,19 @@ const EndpointsTable = ({ producers }) => {
               <TableRow key={`${producer.name}-${index}`}>
                 <TableCell>
                   <div className={classes.healthContainer}>
-                      {producer.name}
-                      {!!producer.endpoints.api.length +
-                        producer.endpoints.ssl.length && (
-                        <Link
-                          component={RouterLink}
-                          state={{ producerId: producer.id }}
-                          to="/endpoints-stats"
-                          color="secondary"
-                        >
-                          <QueryStatsIcon />
-                        </Link>
-                      )}
-                    </div>
+                    {producer.name}
+                    {!!producer.endpoints.api.length +
+                      producer.endpoints.ssl.length && (
+                      <Link
+                        component={RouterLink}
+                        state={{ producerId: producer.id }}
+                        to="/endpoints-stats"
+                        color="secondary"
+                      >
+                        <QueryStatsIcon />
+                      </Link>
+                    )}
+                  </div>
                 </TableCell>
                 <CellList producer={producer} endpointType={'api'} />
                 <CellList producer={producer} endpointType={'ssl'} />

--- a/webapp/src/components/EndpointsTextList/index.js
+++ b/webapp/src/components/EndpointsTextList/index.js
@@ -42,7 +42,7 @@ const EndpointsTextList = ({ type }) => {
 
   return (
     <>
-      {!loading && textList?.length && (
+      {!loading && !!textList?.length && (
         <div className={classes.container}>
           <CopyToClipboard text={textList} />
           {textList}

--- a/webapp/src/components/HealthCheck/index.js
+++ b/webapp/src/components/HealthCheck/index.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { makeStyles } from '@mui/styles'
+import { CircularProgress } from '@mui/material'
 
 import Tooltip from '../Tooltip'
 
@@ -12,6 +13,9 @@ const HealthCheck = ({ children, status }) => {
   const classes = useStyles()
   const [anchorEl, setAnchorEl] = useState(null)
 
+  if (status === undefined)
+    return <CircularProgress className={classes.loading} />
+
   const handlePopoverOpen = (target) => {
     setAnchorEl(target)
   }
@@ -19,8 +23,6 @@ const HealthCheck = ({ children, status }) => {
   const handlePopoverClose = () => {
     setAnchorEl(null)
   }
-
-  if (status === undefined) return
 
   const openPopOver = (event) => {
     handlePopoverOpen(event.target)

--- a/webapp/src/components/HealthCheck/styles.js
+++ b/webapp/src/components/HealthCheck/styles.js
@@ -43,4 +43,8 @@ export default (theme) => ({
   test: {
     boxShadow: '10px 5px 5px red !important',
   },
+  loading: {
+    width: '18px !important',
+    height: '18px !important',
+  }
 })

--- a/webapp/src/components/NodeCard/styles.js
+++ b/webapp/src/components/NodeCard/styles.js
@@ -54,8 +54,8 @@ export default (theme) => ({
     display: 'flex',
     fontWeight: 'normal',
     marginLeft: theme.spacing(3),
-    '& svg': {
-      marginLeft: theme.spacing(2),
+    '& span': {
+      marginRight: theme.spacing(2),
     },
   },
   keysContainer: {


### PR DESCRIPTION
### Use a specific API for health checking based on the features of the nodes.

### What does this PR do?

- Resolve #1170
- To determine the health of the node it will use the API of the first feature it finds, in case it does not have the list of features in the bp.json or none is in the object it will use the chain-api by default.
- Decrease the timeout used to query the API and supported APIs.
- Change non-responsive endpoints.
- Add an animation when the health check indicator is waiting the result.

- The API's added are:

| | Feature |      API   |  
| ----------|----------|:-------------:|
| 1 | chain-api | `/v1/chain/get_info` |
| 2 | atomic-assets-api |    `/atomicassets/v1/config`|  
| 3 | hyperion-v2 | `/v2/health` |    
| 4 | light-api | `/api/status` |  

### Steps to test

1. Run the project locally with wax network.
2. Go to /endpoints page.
3. Check the atomic assets endpoints.
4. Go to /nodes page.
5. Check the health check indicator.

### Screenshots

# Fixing false negative bug

![imagen](https://user-images.githubusercontent.com/66583677/234709183-b77e613d-198c-4cc5-a967-8367b6934470.png)
![imagen](https://user-images.githubusercontent.com/66583677/234709204-7b477f27-b767-42e7-850c-4824ad5d1652.png)

# Show an circular loader when the result of health check is not ready

![imagen](https://user-images.githubusercontent.com/66583677/234709247-0e04b2b4-611d-46fe-8afb-331c87451f50.png)
![imagen](https://user-images.githubusercontent.com/66583677/234709394-e1e2529f-15aa-4982-9237-16252f406cd9.png)
![imagen](https://user-images.githubusercontent.com/66583677/234709410-0a067ff2-d22e-4054-9d3b-338a5c225f76.png)

