### PR TITLE
Chore/review cpu benchmark 1188

### DIFF
--- a/hapi/src/services/cpu.service.js
+++ b/hapi/src/services/cpu.service.js
@@ -52,8 +52,6 @@ const worker = async () => {
   } catch (error) {
     console.error('cpuService.sync', error)
   }
-
-  await cleanOldBenchmarks()
 }
 
 const getBenchmark = async (range = '3 Hours') => {
@@ -87,5 +85,6 @@ const getBenchmark = async (range = '3 Hours') => {
 
 module.exports = {
   worker,
-  getBenchmark
+  getBenchmark,
+  cleanOldBenchmarks
 }

--- a/hapi/src/services/cpu.service.js
+++ b/hapi/src/services/cpu.service.js
@@ -22,6 +22,22 @@ const saveBenchmark = async payload => {
   return data.insert_cpu_one
 }
 
+const cleanOldBenchmarks = async () => {
+  const date = new Date()
+
+  date.setFullYear(date.getFullYear() - 1)
+
+  const mutation = `
+    mutation ($date: timestamptz) {
+      delete_cpu (where: {created_at: {_lt: $date}}) {
+        affected_rows
+      }
+    }
+  `
+
+  await hasuraUtil.request(mutation, { date })
+}
+
 const worker = async () => {
   if (!eosConfig.eosmechanics.account || !eosConfig.eosmechanics.password) {
     return
@@ -36,6 +52,8 @@ const worker = async () => {
   } catch (error) {
     console.error('cpuService.sync', error)
   }
+
+  await cleanOldBenchmarks()
 }
 
 const getBenchmark = async (range = '3 Hours') => {

--- a/hapi/src/workers/producers.worker.js
+++ b/hapi/src/workers/producers.worker.js
@@ -62,6 +62,7 @@ const start = async () => {
 
   if (eosConfig.eosmechanics.account && eosConfig.eosmechanics.password) {
     run('CPU WORKER', cpuService.worker, workersConfig.cpuWorkerInterval)
+    run('CPU WORKER CLEANUP', cpuService.cleanOldBenchmarks, 86400)
   }
 
   if (eosConfig.stateHistoryPluginEndpoint) {

--- a/webapp/src/language/en.airwire-testnet.json
+++ b/webapp/src/language/en.airwire-testnet.json
@@ -19,7 +19,7 @@
     "/node-config>moreDescription": "Use this tool to obtain example config files to help configure a new node on the network.",
     "/ricardian-contract>moreDescription": "The on-chain ricardian contract that describes the validator node agreement of this network.",
     "/>moreDescription": "Find information on the Airwire Test Network and its current status.",
-    "/cpu-benchmark>moreDescription": "A visualization of CPU usage in milliseconds by block producer nodes accounts, with lowest, highest, and average usage data.",
+    "/cpu-benchmark>moreDescription": "A visualization of CPU usage in microseconds by block producer nodes accounts, with lowest, highest, and average usage data.",
     "/block-producers>moreDescription": "A list of the block producers in the network – blockchain accounts registered to run nodes on the network. It includes information from chain tables and their bp.json files.",
     "/nodes>moreDescription": "A list of all the nodes run by block producers comprising the network with specific information such as endpoints and location.",
     "/endpoints>moreDescription": "An updated list of public API endpoints provided by node operators and their health status.",

--- a/webapp/src/language/en.airwire.json
+++ b/webapp/src/language/en.airwire.json
@@ -19,7 +19,7 @@
     "/node-config>moreDescription": "Use this tool to obtain example config files to help configure a new node on the network.",
     "/ricardian-contract>moreDescription": "The on-chain ricardian contract that describes the validator node agreement of this network.",
     "/>moreDescription": "Find information on the Airwire Mainnet and its current status.",
-    "/cpu-benchmark>moreDescription": "A visualization of CPU usage in milliseconds by block producer nodes accounts, with lowest, highest, and average usage data.",
+    "/cpu-benchmark>moreDescription": "A visualization of CPU usage in microseconds by block producer nodes accounts, with lowest, highest, and average usage data.",
     "/block-producers>moreDescription": "A list of the block producers in the network – blockchain accounts registered to run nodes on the network. It includes information from chain tables and their bp.json files.",
     "/nodes>moreDescription": "A list of all the nodes run by block producers comprising the network with specific information such as endpoints and location.",
     "/endpoints>moreDescription": "An updated list of public API endpoints provided by node operators and their health status.",

--- a/webapp/src/language/en.json
+++ b/webapp/src/language/en.json
@@ -346,7 +346,7 @@
     "showList": "Show List"
   },
   "cpuBenchmarkRoute": {
-    "title": "CPU Usage in Milliseconds",
+    "title": "CPU Usage in Microseconds",
     "lowest": "Lowest",
     "highest": "Highest",
     "average": "Average"

--- a/webapp/src/language/en.jungle.json
+++ b/webapp/src/language/en.jungle.json
@@ -22,7 +22,7 @@
     "/node-config>moreDescription": "Use this tool to obtain example config files to help configure a new node on the network.",
     "/ricardian-contract>moreDescription": "The on-chain ricardian contract that describes the validator node agreement of this network.",
     "/>moreDescription": "Monitor the infrastructure of blockchain networks using Antelope + EOSIO blockchain technology.",
-    "/cpu-benchmark>moreDescription": "A visualization of CPU usage in milliseconds by block producer nodes accounts, with lowest, highest, and average usage data.",
+    "/cpu-benchmark>moreDescription": "A visualization of CPU usage in microseconds by block producer nodes accounts, with lowest, highest, and average usage data.",
     "/block-producers>moreDescription": "A list of the block producers in the network – blockchain accounts registered to run nodes on the network. It includes information from chain tables and their bp.json files.",
     "/nodes>moreDescription": "A list of all the nodes run by block producers comprising the network with specific information such as endpoints and location.",
     "/endpoints>moreDescription": "An updated list of public API endpoints provided by node operators and their health status.",

--- a/webapp/src/language/en.lacchain.json
+++ b/webapp/src/language/en.lacchain.json
@@ -22,7 +22,7 @@
     "/>title": "LACChain EOSIO Network Monitor and Infrastructure Dashboard",
     "/>moreDescription": "Monitor the infrastructure of blockchain networks using Antelope + EOSIO blockchain technology.",
     "/cpu-benchmark>title": "CPU Benchmarks  - LACChain EOSIO + Antelope Network Dashboard",
-    "/cpu-benchmark>moreDescription": "A visualization of CPU usage in milliseconds by block producer nodes accounts, with lowest, highest, and average usage data.",
+    "/cpu-benchmark>moreDescription": "A visualization of CPU usage in microseconds by block producer nodes accounts, with lowest, highest, and average usage data.",
     "/block-producers>title": "Block Producers - LACChain EOSIO + Antelope Network Dashboard",
     "/block-producers>moreDescription": "A list of the block producers in the network – blockchain accounts registered to run nodes on the network. It includes information from chain tables and their bp.json files.",
     "/rewards-distribution>title": "Rewards Distribution - LACChain EOSIO + Antelope Network Dashboard",

--- a/webapp/src/language/en.libre-testnet.json
+++ b/webapp/src/language/en.libre-testnet.json
@@ -23,7 +23,7 @@
     "/node-config>moreDescription": "Use this tool to obtain example config files to help configure a new node on the network.",
     "/ricardian-contract>moreDescription": "The on-chain ricardian contract that describes the validator node agreement of this network.",
     "/>moreDescription": "Monitor the infrastructure of blockchain networks using Antelope + EOSIO blockchain technology.",
-    "/cpu-benchmark>moreDescription": "A visualization of CPU usage in milliseconds by block producer nodes accounts, with lowest, highest, and average usage data.",
+    "/cpu-benchmark>moreDescription": "A visualization of CPU usage in microseconds by block producer nodes accounts, with lowest, highest, and average usage data.",
     "/block-producers>moreDescription": "A list of the block producers in the network – blockchain accounts registered to run nodes on the network. It includes information from chain tables and their bp.json files.",
     "/nodes>moreDescription": "A list of all the nodes run by block producers comprising the network with specific information such as endpoints and location.",
     "/endpoints>moreDescription": "An updated list of public API endpoints provided by node operators and their health status.",

--- a/webapp/src/language/en.libre.json
+++ b/webapp/src/language/en.libre.json
@@ -23,7 +23,7 @@
     "/node-config>moreDescription": "Use this tool to obtain example config files to help configure a new node on the network.",
     "/ricardian-contract>moreDescription": "The on-chain ricardian contract that describes the validator node agreement of this network.",
     "/>moreDescription": "Monitor the infrastructure of blockchain networks using Antelope + EOSIO blockchain technology.",
-    "/cpu-benchmark>moreDescription": "A visualization of CPU usage in milliseconds by block producer nodes accounts, with lowest, highest, and average usage data.",
+    "/cpu-benchmark>moreDescription": "A visualization of CPU usage in microseconds by block producer nodes accounts, with lowest, highest, and average usage data.",
     "/block-producers>moreDescription": "A list of the block producers in the network – blockchain accounts registered to run nodes on the network. It includes information from chain tables and their bp.json files.",
     "/nodes>moreDescription": "A list of all the nodes run by block producers comprising the network with specific information such as endpoints and location.",
     "/endpoints>moreDescription": "An updated list of public API endpoints provided by node operators and their health status.",

--- a/webapp/src/language/en.mainnet.json
+++ b/webapp/src/language/en.mainnet.json
@@ -21,7 +21,7 @@
     "/node-config>moreDescription": "Use this tool to obtain example config files to help configure a new node on the network.",
     "/ricardian-contract>moreDescription": "The on-chain ricardian contract that describes the validator node agreement of this network.",
     "/>moreDescription": "Monitor the infrastructure of blockchain networks using Antelope + EOSIO blockchain technology.",
-    "/cpu-benchmark>moreDescription": "A visualization of CPU usage in milliseconds by block producer nodes accounts, with lowest, highest, and average usage data.",
+    "/cpu-benchmark>moreDescription": "A visualization of CPU usage in microseconds by block producer nodes accounts, with lowest, highest, and average usage data.",
     "/block-producers>moreDescription": "A list of the block producers in the network – blockchain accounts registered to run nodes on the network. It includes information from chain tables and their bp.json files.",
     "/nodes>moreDescription": "A list of all the nodes run by block producers comprising the network with specific information such as endpoints and location.",
     "/endpoints>moreDescription": "An updated list of public API endpoints provided by node operators and their health status.",

--- a/webapp/src/language/en.proton-testnet.json
+++ b/webapp/src/language/en.proton-testnet.json
@@ -22,7 +22,7 @@
     "/node-config>moreDescription": "Use this tool to obtain example config files to help configure a new node on the network.",
     "/ricardian-contract>moreDescription": "The on-chain ricardian contract that describes the validator node agreement of this network.",
     "/>moreDescription": "Monitor the infrastructure of blockchain networks using Antelope + EOSIO blockchain technology.",
-    "/cpu-benchmark>moreDescription": "A visualization of CPU usage in milliseconds by block producer nodes accounts, with lowest, highest, and average usage data.",
+    "/cpu-benchmark>moreDescription": "A visualization of CPU usage in microseconds by block producer nodes accounts, with lowest, highest, and average usage data.",
     "/block-producers>moreDescription": "A list of the block producers in the network – blockchain accounts registered to run nodes on the network. It includes information from chain tables and their bp.json files.",
     "/nodes>moreDescription": "A list of all the nodes run by block producers comprising the network with specific information such as endpoints and location.",
     "/endpoints>moreDescription": "An updated list of public API endpoints provided by node operators and their health status.",

--- a/webapp/src/language/en.proton.json
+++ b/webapp/src/language/en.proton.json
@@ -22,7 +22,7 @@
     "/node-config>moreDescription": "Use this tool to obtain example config files to help configure a new node on the network.",
     "/ricardian-contract>moreDescription": "The on-chain ricardian contract that describes the validator node agreement of this network.",
     "/>moreDescription": "Monitor the infrastructure of blockchain networks using Antelope + EOSIO blockchain technology.",
-    "/cpu-benchmark>moreDescription": "A visualization of CPU usage in milliseconds by block producer nodes accounts, with lowest, highest, and average usage data.",
+    "/cpu-benchmark>moreDescription": "A visualization of CPU usage in microseconds by block producer nodes accounts, with lowest, highest, and average usage data.",
     "/block-producers>moreDescription": "A list of the block producers in the network – blockchain accounts registered to run nodes on the network. It includes information from chain tables and their bp.json files.",
     "/nodes>moreDescription": "A list of all the nodes run by block producers comprising the network with specific information such as endpoints and location.",
     "/endpoints>moreDescription": "An updated list of public API endpoints provided by node operators and their health status.",

--- a/webapp/src/language/en.telos-testnet.json
+++ b/webapp/src/language/en.telos-testnet.json
@@ -22,7 +22,7 @@
     "/node-config>moreDescription": "Use this tool to obtain example config files to help configure a new node on the network.",
     "/ricardian-contract>moreDescription": "The on-chain ricardian contract that describes the validator node agreement of this network.",
     "/>moreDescription": "Monitor the infrastructure of blockchain networks using Antelope + EOSIO blockchain technology.",
-    "/cpu-benchmark>moreDescription": "A visualization of CPU usage in milliseconds by block producer nodes accounts, with lowest, highest, and average usage data.",
+    "/cpu-benchmark>moreDescription": "A visualization of CPU usage in microseconds by block producer nodes accounts, with lowest, highest, and average usage data.",
     "/block-producers>moreDescription": "A list of the block producers in the network – blockchain accounts registered to run nodes on the network. It includes information from chain tables and their bp.json files.",
     "/nodes>moreDescription": "A list of all the nodes run by block producers comprising the network with specific information such as endpoints and location.",
     "/endpoints>moreDescription": "An updated list of public API endpoints provided by node operators and their health status.",

--- a/webapp/src/language/en.telos.json
+++ b/webapp/src/language/en.telos.json
@@ -22,7 +22,7 @@
     "/node-config>moreDescription": "Use this tool to obtain example config files to help configure a new node on the network.",
     "/ricardian-contract>moreDescription": "The on-chain ricardian contract that describes the validator node agreement of this network.",
     "/>moreDescription": "Monitor the infrastructure of blockchain networks using Antelope + EOSIO blockchain technology.",
-    "/cpu-benchmark>moreDescription": "A visualization of CPU usage in milliseconds by block producer nodes accounts, with lowest, highest, and average usage data.",
+    "/cpu-benchmark>moreDescription": "A visualization of CPU usage in microseconds by block producer nodes accounts, with lowest, highest, and average usage data.",
     "/block-producers>moreDescription": "A list of the block producers in the network – blockchain accounts registered to run nodes on the network. It includes information from chain tables and their bp.json files.",
     "/nodes>moreDescription": "A list of all the nodes run by block producers comprising the network with specific information such as endpoints and location.",
     "/endpoints>moreDescription": "An updated list of public API endpoints provided by node operators and their health status.",

--- a/webapp/src/language/en.ultra-testnet.json
+++ b/webapp/src/language/en.ultra-testnet.json
@@ -24,7 +24,7 @@
     "/node-config>moreDescription": "Use this tool to obtain example config files to help configure a new node on the network.",
     "/ricardian-contract>moreDescription": "The on-chain ricardian contract that describes the validator node agreement of this network.",
     "/>moreDescription": "Find information on the Ultra Test Network and its current status.",
-    "/cpu-benchmark>moreDescription": "A visualization of CPU usage in milliseconds by block producer nodes accounts, with lowest, highest, and average usage data.",
+    "/cpu-benchmark>moreDescription": "A visualization of CPU usage in microseconds by block producer nodes accounts, with lowest, highest, and average usage data.",
     "/block-producers>moreDescription": "A list of the block producers in the network – blockchain accounts registered to run nodes on the network. It includes information from chain tables and their bp.json files.",
     "/nodes>moreDescription": "A list of all the nodes run by block producers comprising the network with specific information such as endpoints and location.",
     "/endpoints>moreDescription": "An updated list of public API endpoints provided by node operators and their health status.",

--- a/webapp/src/language/en.wax-testnet.json
+++ b/webapp/src/language/en.wax-testnet.json
@@ -22,7 +22,7 @@
     "/node-config>moreDescription": "Use this tool to obtain example config files to help configure a new node on the network.",
     "/ricardian-contract>moreDescription": "The on-chain ricardian contract that describes the validator node agreement of this network.",
     "/>moreDescription": "Monitor the infrastructure of blockchain networks using Antelope + EOSIO blockchain technology.",
-    "/cpu-benchmark>moreDescription": "A visualization of CPU usage in milliseconds by block producer nodes accounts, with lowest, highest, and average usage data.",
+    "/cpu-benchmark>moreDescription": "A visualization of CPU usage in microseconds by block producer nodes accounts, with lowest, highest, and average usage data.",
     "/block-producers>moreDescription": "A list of the block producers in the network – blockchain accounts registered to run nodes on the network. It includes information from chain tables and their bp.json files.",
     "/nodes>moreDescription": "A list of all the nodes run by block producers comprising the network with specific information such as endpoints and location.",
     "/endpoints>moreDescription": "An updated list of public API endpoints provided by node operators and their health status.",

--- a/webapp/src/language/en.wax.json
+++ b/webapp/src/language/en.wax.json
@@ -22,7 +22,7 @@
     "/node-config>moreDescription": "Use this tool to obtain example config files to help configure a new node on the network.",
     "/ricardian-contract>moreDescription": "The on-chain ricardian contract that describes the validator node agreement of this network.",
     "/>moreDescription": "Monitor the infrastructure of blockchain networks using Antelope + EOSIO blockchain technology.",
-    "/cpu-benchmark>moreDescription": "A visualization of CPU usage in milliseconds by block producer nodes accounts, with lowest, highest, and average usage data.",
+    "/cpu-benchmark>moreDescription": "A visualization of CPU usage in microseconds by block producer nodes accounts, with lowest, highest, and average usage data.",
     "/block-producers>moreDescription": "A list of the block producers in the network – blockchain accounts registered to run nodes on the network. It includes information from chain tables and their bp.json files.",
     "/nodes>moreDescription": "A list of all the nodes run by block producers comprising the network with specific information such as endpoints and location.",
     "/endpoints>moreDescription": "An updated list of public API endpoints provided by node operators and their health status.",

--- a/webapp/src/language/es.airwire-testnet.json
+++ b/webapp/src/language/es.airwire-testnet.json
@@ -18,7 +18,7 @@
     "/node-config>moreDescription": "Utilice esta herramienta para obtener archivos de configuración de ejemplo para ayudar a configurar un nuevo nodo en la red.",
     "/ricardian-contract>moreDescription": "Lea más sobre el Acuerdo de nodo de validación de esta red. Contáctenos si tiene alguna consulta.",
     "/>moreDescription": "Encuentre datos de redes blockchain utilizando la tecnología EOSIO. Vea más redes aquí: https://antelope.tools/.",
-    "/cpu-benchmark>moreDescription": "Una visualización del uso de CPU en milisegundos por cuentas de nodos productores de bloques, con datos de uso más bajos, más altos y promedio.",
+    "/cpu-benchmark>moreDescription": "Una visualización del uso de CPU en microsegundos por cuentas de nodos productores de bloques, con datos de uso más bajos, más altos y promedio.",
     "/block-producers>moreDescription": "Una lista de los productores de bloques en la red: cuentas de blockchain registradas para ejecutar nodos en la red. Incluye información de tablas en cadena y sus archivos bp.json.",
     "/nodes>moreDescription": "Una lista de todos los nodos ejecutados por entidades que componen la red con información específica como puntos finales y ubicación.",
     "/endpoints>moreDescription": "Una lista actualizada de los puntos finales de la API pública proporcionada por los operadores de nodos en la red.",

--- a/webapp/src/language/es.airwire.json
+++ b/webapp/src/language/es.airwire.json
@@ -18,7 +18,7 @@
     "/node-config>moreDescription": "Utilice esta herramienta para obtener archivos de configuración de ejemplo para ayudar a configurar un nuevo nodo en la red.",
     "/ricardian-contract>moreDescription": "Lea más sobre el Acuerdo de nodo de validación de esta red. Contáctenos si tiene alguna consulta.",
     "/>moreDescription": "Encuentre datos de redes blockchain utilizando la tecnología EOSIO. Vea más redes aquí: https://antelope.tools/.",
-    "/cpu-benchmark>moreDescription": "Una visualización del uso de CPU en milisegundos por cuentas de nodos productores de bloques, con datos de uso más bajos, más altos y promedio.",
+    "/cpu-benchmark>moreDescription": "Una visualización del uso de CPU en microsegundos por cuentas de nodos productores de bloques, con datos de uso más bajos, más altos y promedio.",
     "/block-producers>moreDescription": "Una lista de los productores de bloques en la red: cuentas de blockchain registradas para ejecutar nodos en la red. Incluye información de tablas en cadena y sus archivos bp.json.",
     "/nodes>moreDescription": "Una lista de todos los nodos ejecutados por entidades que componen la red con información específica como puntos finales y ubicación.",
     "/endpoints>moreDescription": "Una lista actualizada de los puntos finales de la API pública proporcionada por los operadores de nodos en la red.",

--- a/webapp/src/language/es.json
+++ b/webapp/src/language/es.json
@@ -45,7 +45,7 @@
     "4 Days": "4 Días",
     "7 Days": "7 Días",
     "14 Days": "14 Días",
-    "1 Month": "6 Mes",
+    "1 Month": "1 Mes",
     "2 Months": "2 Meses",
     "3 Months": "3 Meses",
     "6 Months": "6 Meses",
@@ -351,7 +351,7 @@
     "showList": "Ver la lista"
   },
   "cpuBenchmarkRoute": {
-    "title": "Resumen del uso de la CPU en Milisegundos",
+    "title": "Resumen del uso de la CPU en Microsegundos",
     "lowest": "Más bajo",
     "highest": "Más alto",
     "average": "Promedio"

--- a/webapp/src/language/es.jungle.json
+++ b/webapp/src/language/es.jungle.json
@@ -20,7 +20,7 @@
     "/node-config>moreDescription": "Utilice esta herramienta para obtener archivos de configuración de ejemplo para ayudar a configurar un nuevo nodo en la red.",
     "/ricardian-contract>moreDescription": "Lea más sobre el Acuerdo de nodo de validación de esta red. Contáctenos si tiene alguna consulta.",
     "/>moreDescription": "Encuentre datos de redes blockchain utilizando la tecnología EOSIO. Vea más redes aquí: https://antelope.tools/.",
-    "/cpu-benchmark>moreDescription": "Una visualización del uso de CPU en milisegundos por cuentas de nodos productores de bloques, con datos de uso más bajos, más altos y promedio.",
+    "/cpu-benchmark>moreDescription": "Una visualización del uso de CPU en microsegundos por cuentas de nodos productores de bloques, con datos de uso más bajos, más altos y promedio.",
     "/block-producers>moreDescription": "Una lista de los productores de bloques en la red: cuentas de blockchain registradas para ejecutar nodos en la red. Incluye información de tablas en cadena y sus archivos bp.json.",
     "/nodes>moreDescription": "Una lista de todos los nodos ejecutados por entidades que componen la red con información específica como puntos finales y ubicación.",
     "/endpoints>moreDescription": "Una lista actualizada de los puntos finales de la API pública proporcionada por los operadores de nodos en la red.",

--- a/webapp/src/language/es.lacchain.json
+++ b/webapp/src/language/es.lacchain.json
@@ -34,7 +34,7 @@
     "/node-config>moreDescription": "Utilice esta herramienta para obtener archivos de configuración de ejemplo para ayudar a configurar un nuevo nodo en la red.",
     "/ricardian-contract>moreDescription": "Lea más sobre el Acuerdo de nodo de validación de esta red. Contáctenos si tiene alguna consulta.",
     "/>moreDescription": "Encuentre datos de redes blockchain utilizando la tecnología EOSIO. Vea más redes aquí: https://antelope.tools/.",
-    "/cpu-benchmark>moreDescription": "Una visualización del uso de CPU en milisegundos por cuentas de nodos productores de bloques, con datos de uso más bajos, más altos y promedio.",
+    "/cpu-benchmark>moreDescription": "Una visualización del uso de CPU en microsegundos por cuentas de nodos productores de bloques, con datos de uso más bajos, más altos y promedio.",
     "/block-producers>moreDescription": "Una lista de los productores de bloques en la red: cuentas de blockchain registradas para ejecutar nodos en la red. Incluye información de tablas en cadena y sus archivos bp.json.",
     "/nodes>moreDescription": "Una lista de todos los nodos ejecutados por entidades que componen la red con información específica como puntos finales y ubicación.",
     "/endpoints>moreDescription": "Una lista actualizada de los puntos finales de la API pública proporcionada por los operadores de nodos en la red.",

--- a/webapp/src/language/es.libre-testnet.json
+++ b/webapp/src/language/es.libre-testnet.json
@@ -21,7 +21,7 @@
     "/node-config>moreDescription": "Utilice esta herramienta para obtener archivos de configuración de ejemplo para ayudar a configurar un nuevo nodo en la red.",
     "/ricardian-contract>moreDescription": "Lea más sobre el Acuerdo de nodo de validación de esta red. Contáctenos si tiene alguna consulta.",
     "/>moreDescription": "Encuentre datos de redes blockchain utilizando la tecnología EOSIO. Vea más redes aquí: https://antelope.tools/.",
-    "/cpu-benchmark>moreDescription": "Una visualización del uso de CPU en milisegundos por cuentas de nodos productores de bloques, con datos de uso más bajos, más altos y promedio.",
+    "/cpu-benchmark>moreDescription": "Una visualización del uso de CPU en microsegundos por cuentas de nodos productores de bloques, con datos de uso más bajos, más altos y promedio.",
     "/block-producers>moreDescription": "Una lista de los productores de bloques en la red: cuentas de blockchain registradas para ejecutar nodos en la red. Incluye información de tablas en cadena y sus archivos bp.json.",
     "/nodes>moreDescription": "Una lista de todos los nodos ejecutados por entidades que componen la red con información específica como puntos finales y ubicación.",
     "/endpoints>moreDescription": "Una lista actualizada de los puntos finales de la API pública proporcionada por los operadores de nodos en la red.",

--- a/webapp/src/language/es.libre.json
+++ b/webapp/src/language/es.libre.json
@@ -21,7 +21,7 @@
     "/node-config>moreDescription": "Utilice esta herramienta para obtener archivos de configuración de ejemplo para ayudar a configurar un nuevo nodo en la red.",
     "/ricardian-contract>moreDescription": "Lea más sobre el Acuerdo de nodo de validación de esta red. Contáctenos si tiene alguna consulta.",
     "/>moreDescription": "Encuentre datos de redes blockchain utilizando la tecnología EOSIO. Vea más redes aquí: https://antelope.tools/.",
-    "/cpu-benchmark>moreDescription": "Una visualización del uso de CPU en milisegundos por cuentas de nodos productores de bloques, con datos de uso más bajos, más altos y promedio.",
+    "/cpu-benchmark>moreDescription": "Una visualización del uso de CPU en microsegundos por cuentas de nodos productores de bloques, con datos de uso más bajos, más altos y promedio.",
     "/block-producers>moreDescription": "Una lista de los productores de bloques en la red: cuentas de blockchain registradas para ejecutar nodos en la red. Incluye información de tablas en cadena y sus archivos bp.json.",
     "/nodes>moreDescription": "Una lista de todos los nodos ejecutados por entidades que componen la red con información específica como puntos finales y ubicación.",
     "/endpoints>moreDescription": "Una lista actualizada de los puntos finales de la API pública proporcionada por los operadores de nodos en la red.",

--- a/webapp/src/language/es.mainnet.json
+++ b/webapp/src/language/es.mainnet.json
@@ -20,7 +20,7 @@
     "/node-config>moreDescription": "Utilice esta herramienta para obtener archivos de configuración de ejemplo para ayudar a configurar un nuevo nodo en la red.",
     "/ricardian-contract>moreDescription": "Lea más sobre el Acuerdo de nodo de validación de esta red. Contáctenos si tiene alguna consulta.",
     "/>moreDescription": "Encuentre datos de redes blockchain utilizando la tecnología EOSIO. Vea más redes aquí: https://antelope.tools/.",
-    "/cpu-benchmark>moreDescription": "Una visualización del uso de CPU en milisegundos por cuentas de nodos productores de bloques, con datos de uso más bajos, más altos y promedio.",
+    "/cpu-benchmark>moreDescription": "Una visualización del uso de CPU en microsegundos por cuentas de nodos productores de bloques, con datos de uso más bajos, más altos y promedio.",
     "/block-producers>moreDescription": "Una lista de los productores de bloques en la red: cuentas de blockchain registradas para ejecutar nodos en la red. Incluye información de tablas en cadena y sus archivos bp.json.",
     "/nodes>moreDescription": "Una lista de todos los nodos ejecutados por entidades que componen la red con información específica como puntos finales y ubicación.",
     "/endpoints>moreDescription": "Una lista actualizada de los puntos finales de la API pública proporcionada por los operadores de nodos en la red.",

--- a/webapp/src/language/es.proton-testnet.json
+++ b/webapp/src/language/es.proton-testnet.json
@@ -20,7 +20,7 @@
     "/node-config>moreDescription": "Utilice esta herramienta para obtener archivos de configuración de ejemplo para ayudar a configurar un nuevo nodo en la red.",
     "/ricardian-contract>moreDescription": "Lea más sobre el Acuerdo de nodo de validación de esta red. Contáctenos si tiene alguna consulta.",
     "/>moreDescription": "Encuentre datos de redes blockchain utilizando la tecnología EOSIO. Vea más redes aquí: https://antelope.tools/.",
-    "/cpu-benchmark>moreDescription": "Una visualización del uso de CPU en milisegundos por cuentas de nodos productores de bloques, con datos de uso más bajos, más altos y promedio.",
+    "/cpu-benchmark>moreDescription": "Una visualización del uso de CPU en microsegundos por cuentas de nodos productores de bloques, con datos de uso más bajos, más altos y promedio.",
     "/block-producers>moreDescription": "Una lista de los productores de bloques en la red: cuentas de blockchain registradas para ejecutar nodos en la red. Incluye información de tablas en cadena y sus archivos bp.json.",
     "/nodes>moreDescription": "Una lista de todos los nodos ejecutados por entidades que componen la red con información específica como puntos finales y ubicación.",
     "/endpoints-stats>moreDescription": "Estadísticas del tiempo de respuesta desde Costa Rica y la disponibilidad de los puntos finales de un productor",

--- a/webapp/src/language/es.proton.json
+++ b/webapp/src/language/es.proton.json
@@ -20,7 +20,7 @@
     "/node-config>moreDescription": "Utilice esta herramienta para obtener archivos de configuración de ejemplo para ayudar a configurar un nuevo nodo en la red.",
     "/ricardian-contract>moreDescription": "Lea más sobre el Acuerdo de nodo de validación de esta red. Contáctenos si tiene alguna consulta.",
     "/>moreDescription": "Encuentre datos de redes blockchain utilizando la tecnología EOSIO. Vea más redes aquí: https://antelope.tools/.",
-    "/cpu-benchmark>moreDescription": "Una visualización del uso de CPU en milisegundos por cuentas de nodos productores de bloques, con datos de uso más bajos, más altos y promedio.",
+    "/cpu-benchmark>moreDescription": "Una visualización del uso de CPU en microsegundos por cuentas de nodos productores de bloques, con datos de uso más bajos, más altos y promedio.",
     "/block-producers>moreDescription": "Una lista de los productores de bloques en la red: cuentas de blockchain registradas para ejecutar nodos en la red. Incluye información de tablas en cadena y sus archivos bp.json.",
     "/nodes>moreDescription": "Una lista de todos los nodos ejecutados por entidades que componen la red con información específica como puntos finales y ubicación.",
     "/endpoints>moreDescription": "Una lista actualizada de los puntos finales de la API pública proporcionada por los operadores de nodos en la red.",

--- a/webapp/src/language/es.telos-testnet.json
+++ b/webapp/src/language/es.telos-testnet.json
@@ -20,7 +20,7 @@
     "/node-config>moreDescription": "Utilice esta herramienta para obtener archivos de configuración de ejemplo para ayudar a configurar un nuevo nodo en la red.",
     "/ricardian-contract>moreDescription": "Lea más sobre el Acuerdo de nodo de validación de esta red. Contáctenos si tiene alguna consulta.",
     "/>moreDescription": "Encuentre datos de redes blockchain utilizando la tecnología EOSIO. Vea más redes aquí: https://antelope.tools/.",
-    "/cpu-benchmark>moreDescription": "Una visualización del uso de CPU en milisegundos por cuentas de nodos productores de bloques, con datos de uso más bajos, más altos y promedio.",
+    "/cpu-benchmark>moreDescription": "Una visualización del uso de CPU en microsegundos por cuentas de nodos productores de bloques, con datos de uso más bajos, más altos y promedio.",
     "/block-producers>moreDescription": "Una lista de los productores de bloques en la red: cuentas de blockchain registradas para ejecutar nodos en la red. Incluye información de tablas en cadena y sus archivos bp.json.",
     "/nodes>moreDescription": "Una lista de todos los nodos ejecutados por entidades que componen la red con información específica como puntos finales y ubicación.",
     "/endpoints>moreDescription": "Una lista actualizada de los puntos finales de la API pública proporcionada por los operadores de nodos en la red.",

--- a/webapp/src/language/es.telos.json
+++ b/webapp/src/language/es.telos.json
@@ -20,7 +20,7 @@
     "/node-config>moreDescription": "Utilice esta herramienta para obtener archivos de configuración de ejemplo para ayudar a configurar un nuevo nodo en la red.",
     "/ricardian-contract>moreDescription": "Lea más sobre el Acuerdo de nodo de validación de esta red. Contáctenos si tiene alguna consulta.",
     "/>moreDescription": "Encuentre datos de redes blockchain utilizando la tecnología EOSIO. Vea más redes aquí: https://antelope.tools/.",
-    "/cpu-benchmark>moreDescription": "Una visualización del uso de CPU en milisegundos por cuentas de nodos productores de bloques, con datos de uso más bajos, más altos y promedio.",
+    "/cpu-benchmark>moreDescription": "Una visualización del uso de CPU en microsegundos por cuentas de nodos productores de bloques, con datos de uso más bajos, más altos y promedio.",
     "/block-producers>moreDescription": "Una lista de los productores de bloques en la red: cuentas de blockchain registradas para ejecutar nodos en la red. Incluye información de tablas en cadena y sus archivos bp.json.",
     "/nodes>moreDescription": "Una lista de todos los nodos ejecutados por entidades que componen la red con información específica como puntos finales y ubicación.",
     "/endpoints>moreDescription": "Una lista actualizada de los puntos finales de la API pública proporcionada por los operadores de nodos en la red.",

--- a/webapp/src/language/es.ultra-testnet.json
+++ b/webapp/src/language/es.ultra-testnet.json
@@ -22,7 +22,7 @@
     "/node-config>moreDescription": "Utilice esta herramienta para obtener archivos de configuración de ejemplo para ayudar a configurar un nuevo nodo en la red.",
     "/ricardian-contract>moreDescription": "Lea más sobre el Acuerdo de nodo de validación de esta red. Contáctenos si tiene alguna consulta.",
     "/>moreDescription": "Encuentre datos de redes blockchain utilizando la tecnología EOSIO. Vea más redes aquí: https://antelope.tools/.",
-    "/cpu-benchmark>moreDescription": "Una visualización del uso de CPU en milisegundos por cuentas de nodos productores de bloques, con datos de uso más bajos, más altos y promedio.",
+    "/cpu-benchmark>moreDescription": "Una visualización del uso de CPU en microsegundos por cuentas de nodos productores de bloques, con datos de uso más bajos, más altos y promedio.",
     "/block-producers>moreDescription": "Una lista de los productores de bloques en la red: cuentas de blockchain registradas para ejecutar nodos en la red. Incluye información de tablas en cadena y sus archivos bp.json.",
     "/nodes>moreDescription": "Una lista de todos los nodos ejecutados por entidades que componen la red con información específica como puntos finales y ubicación.",
     "/endpoints>moreDescription": "Una lista actualizada de los puntos finales de la API pública proporcionada por los operadores de nodos en la red.",

--- a/webapp/src/language/es.wax-testnet.json
+++ b/webapp/src/language/es.wax-testnet.json
@@ -20,7 +20,7 @@
     "/node-config>moreDescription": "Utilice esta herramienta para obtener archivos de configuración de ejemplo para ayudar a configurar un nuevo nodo en la red.",
     "/ricardian-contract>moreDescription": "Lea más sobre el Acuerdo de nodo de validación de esta red. Contáctenos si tiene alguna consulta.",
     "/>moreDescription": "Encuentre datos de redes blockchain utilizando la tecnología EOSIO. Vea más redes aquí: https://antelope.tools/.",
-    "/cpu-benchmark>moreDescription": "Una visualización del uso de CPU en milisegundos por cuentas de nodos productores de bloques, con datos de uso más bajos, más altos y promedio.",
+    "/cpu-benchmark>moreDescription": "Una visualización del uso de CPU en microsegundos por cuentas de nodos productores de bloques, con datos de uso más bajos, más altos y promedio.",
     "/block-producers>moreDescription": "Una lista de los productores de bloques en la red: cuentas de blockchain registradas para ejecutar nodos en la red. Incluye información de tablas en cadena y sus archivos bp.json.",
     "/nodes>moreDescription": "Una lista de todos los nodos ejecutados por entidades que componen la red con información específica como puntos finales y ubicación.",
     "/endpoints>moreDescription": "Una lista actualizada de los puntos finales de la API pública proporcionada por los operadores de nodos en la red.",

--- a/webapp/src/language/es.wax.json
+++ b/webapp/src/language/es.wax.json
@@ -20,7 +20,7 @@
     "/node-config>moreDescription": "Utilice esta herramienta para obtener archivos de configuración de ejemplo para ayudar a configurar un nuevo nodo en la red.",
     "/ricardian-contract>moreDescription": "Lea más sobre el Acuerdo de nodo de validación de esta red. Contáctenos si tiene alguna consulta.",
     "/>moreDescription": "Encuentre datos de redes blockchain utilizando la tecnología EOSIO. Vea más redes aquí: https://antelope.tools/.",
-    "/cpu-benchmark>moreDescription": "Una visualización del uso de CPU en milisegundos por cuentas de nodos productores de bloques, con datos de uso más bajos, más altos y promedio.",
+    "/cpu-benchmark>moreDescription": "Una visualización del uso de CPU en microsegundos por cuentas de nodos productores de bloques, con datos de uso más bajos, más altos y promedio.",
     "/block-producers>moreDescription": "Una lista de los productores de bloques en la red: cuentas de blockchain registradas para ejecutar nodos en la red. Incluye información de tablas en cadena y sus archivos bp.json.",
     "/nodes>moreDescription": "Una lista de todos los nodos ejecutados por entidades que componen la red con información específica como puntos finales y ubicación.",
     "/endpoints>moreDescription": "Una lista actualizada de los puntos finales de la API pública proporcionada por los operadores de nodos en la red.",

--- a/webapp/src/routes/index.js
+++ b/webapp/src/routes/index.js
@@ -12,6 +12,7 @@ import {
   Inbox as InboxIcon,
   Cpu as CpuIcon,
 } from 'react-feather'
+import QueryStatsIcon from '@mui/icons-material/QueryStats'
 
 import { eosConfig, generalConfig } from '../config'
 import {
@@ -121,7 +122,7 @@ const defaultRoutes = [
   },
   {
     name: 'endpointsStats',
-    icon: <ActivityIcon />,
+    icon: <QueryStatsIcon />,
     component: EndpointsStats,
     path: '/endpoints-stats',
     exact: true,
@@ -181,7 +182,7 @@ const lacchainRoutes = [
   },
   {
     name: 'endpointsStats',
-    icon: <ActivityIcon />,
+    icon: <QueryStatsIcon />,
     component: EndpointsStats,
     path: '/endpoints-stats',
     exact: true,


### PR DESCRIPTION
### Review cpu benchmark

### What does this PR do?

- Resolve #1188
- Add a function for daily clearing of cpu benchmark records from a year ago
- Refactor frontend code to format the data of the cpu benchmarks
- Change milliseconds to microseconds
- Change duplicated icon in the sidebar

### Steps to test

1. Run the project locally with libre testnet configuration
2. Go to cpu benchmark page
3. Check the page

### Screenshot

![imagen](https://github.com/edenia/antelope-tools/assets/66583677/f142a2d0-2996-41f5-bf04-a49243fd7258)
