### PR TITLE
Fix/wrong bp cpu benchmark 1196

### DIFF
--- a/hapi/src/services/cpu.service.js
+++ b/hapi/src/services/cpu.service.js
@@ -45,9 +45,12 @@ const worker = async () => {
 
   try {
     const { block, transaction } = await eosmechanicsUtil.cpu()
+
     await saveBenchmark({
       account: block.producer,
-      usage: transaction.processed.receipt.cpu_usage_us
+      usage: block?.transactions.find(
+        trx => trx?.trx?.id === transaction.processed.id
+      ).cpu_usage_us
     })
   } catch (error) {
     console.error('cpuService.sync', error)

--- a/hapi/src/utils/eosmechanics.util.js
+++ b/hapi/src/utils/eosmechanics.util.js
@@ -2,6 +2,10 @@ const { eosConfig } = require('../config')
 
 const eosUtil = require('./eos.util')
 
+const includesTransaction = (block, transactionId) => {
+  return block?.transactions.some(trx => trx?.trx?.id === transactionId)
+}
+
 const transact = async actions => {
   if (eosConfig.eosmechanics.includeTransaction) {
     actions.push(eosConfig.eosmechanics.includeTransaction)
@@ -13,24 +17,19 @@ const transact = async actions => {
     eosConfig.eosmechanics.password
   )
 
-  const findTransaction = trx => trx?.trx?.id === transaction?.processed?.id
+  const { id: transactionId, block_num: blockNum } = transaction?.processed
   const maxAttempts = 3
   let currentAttempt = 0
   let block
 
   await new Promise(resolve => setTimeout(() => resolve(), 1000))
 
-  while (
-    !block?.transactions.some(findTransaction) &&
-    currentAttempt < maxAttempts
-  ) {
-    block = await eosUtil.getBlock(
-      transaction.processed.block_num + currentAttempt
-    )
+  while (!includesTransaction(block, transactionId) && currentAttempt < maxAttempts) {
+    block = await eosUtil.getBlock(blockNum + currentAttempt)
     currentAttempt += 1
   }
 
-  if (!block?.transactions.some(findTransaction)) {
+  if (!includesTransaction(block, transactionId)) {
     throw new Error(
       'Attempts to find the block in which the transaction was added have been exhausted.'
     )

--- a/webapp/src/routes/Faucet/index.js
+++ b/webapp/src/routes/Faucet/index.js
@@ -58,7 +58,7 @@ const Faucet = () => {
         variables: {
           token: reCaptchaToken,
           public_key: createAccountValues.publicKey,
-          name: createAccountValues.accountName,
+          name: createAccountValues.accountName || '',
         },
       })
 


### PR DESCRIPTION
### Get the correct BP that processed the transaction

### What does this PR do?

- Resolve #1196
- Use the cpu usage from the block in which the transaction is present
- fix input.name must be a string of faucet 

### Steps to test

1. Run the project locally with the libre testnet configuration
2. Go to the CPU benchmark route 
3. Check the results

### Screenshots

![imagen](https://github.com/edenia/antelope-tools/assets/66583677/52d2eaa8-2302-4f5d-b9b5-386e17e5909e)

