### PR TITLE
Fix/libre and ultra testnet create account 1200

### DIFF
--- a/hapi/src/routes/create-faucet-account.route.js
+++ b/hapi/src/routes/create-faucet-account.route.js
@@ -6,7 +6,8 @@ const {
   eosUtil,
   axiosUtil,
   googleRecaptchaEnterpriseUtil,
-  getCreateAccountDataUtil
+  getCreateAccountDataUtil,
+  sleepFor
 } = require('../utils')
 
 module.exports = {
@@ -43,25 +44,29 @@ module.exports = {
         eosConfig.faucet.password
       )
 
+      await sleepFor(1)
+
       const {
-        data: { account_name: account, permissions }
+        data: { accounts }
       } = await axiosUtil.instance.post(
-        `${eosConfig.apiEndpoint}/v1/chain/get_account`,
+        `${eosConfig.apiEndpoint}/v1/chain/get_accounts_by_authorizers`,
         {
-          account_name: input.name
+          keys: [input.public_key]
         }
       )
 
-      const keys = permissions[0]?.required_auth?.keys || []
-      const key = keys[0]?.key
+      const response = accounts.find(account => account.account_name === input.name)
 
-      if (account === input.name && key === input.public_key) {
-        return { account }
-      }
+      if (!response) throw new Error('Account creation failed')
 
-      return Boom.badData('Wrong key format')
+      return { account: input.name }
     } catch (err) {
-      throw Boom.badRequest(err.message)
+      const errorDetail =
+        err?.response?.data?.error?.details[0]?.message?.substring(0, 11)
+
+      return 'unknown key' === errorDetail
+        ? Boom.badRequest('Account creation failed')
+        : Boom.badRequest(err.message)
     }
   },
   options: {

--- a/hapi/src/routes/create-faucet-account.route.js
+++ b/hapi/src/routes/create-faucet-account.route.js
@@ -59,7 +59,9 @@ module.exports = {
         input.name = transaction?.processed?.action_traces[0]?.act?.data?.name
       }
 
-      const response = accounts.find(account => account.account_name === input.name)
+      const response = accounts.find(
+        account => account.account_name === input.name || !input.name
+      )
 
       if (!response) throw new Error('Account creation failed')
 

--- a/hapi/src/routes/create-faucet-account.route.js
+++ b/hapi/src/routes/create-faucet-account.route.js
@@ -22,7 +22,7 @@ module.exports = {
         throw Boom.badRequest('Are you a human?')
       }
 
-      await eosUtil.transact(
+      const transaction = await eosUtil.transact(
         [
           {
             authorization: [

--- a/hapi/src/routes/create-faucet-account.route.js
+++ b/hapi/src/routes/create-faucet-account.route.js
@@ -60,7 +60,7 @@ module.exports = {
       }
 
       const newAccount = accounts.find(
-        account => account.account_name === input.name || !input.name
+        (account) => account.account_name === input.name || !input.name
       )
 
       if (!newAccount) throw new Error('Account creation failed')
@@ -70,7 +70,7 @@ module.exports = {
       const errorDetail =
         err?.response?.data?.error?.details[0]?.message?.substring(0, 11)
 
-      return 'unknown key' === errorDetail
+      return errorDetail === 'unknown key'
         ? Boom.badRequest('Account creation failed')
         : Boom.badRequest(err.message)
     }

--- a/hapi/src/routes/create-faucet-account.route.js
+++ b/hapi/src/routes/create-faucet-account.route.js
@@ -55,6 +55,10 @@ module.exports = {
         }
       )
 
+      if (!input.name) {
+        input.name = transaction?.processed?.action_traces[0]?.act?.data?.name
+      }
+
       const response = accounts.find(account => account.account_name === input.name)
 
       if (!response) throw new Error('Account creation failed')

--- a/hapi/src/routes/create-faucet-account.route.js
+++ b/hapi/src/routes/create-faucet-account.route.js
@@ -59,13 +59,13 @@ module.exports = {
         input.name = transaction?.processed?.action_traces[0]?.act?.data?.name
       }
 
-      const response = accounts.find(
+      const newAccount = accounts.find(
         account => account.account_name === input.name || !input.name
       )
 
-      if (!response) throw new Error('Account creation failed')
+      if (!newAccount) throw new Error('Account creation failed')
 
-      return { account: input.name }
+      return { account: newAccount.account_name }
     } catch (err) {
       const errorDetail =
         err?.response?.data?.error?.details[0]?.message?.substring(0, 11)

--- a/webapp/src/gql/faucet.gql.js
+++ b/webapp/src/gql/faucet.gql.js
@@ -1,8 +1,12 @@
 import gql from 'graphql-tag'
 
-export const CREATE_ACCOUNT_MUTATION = gql`
-  mutation ($token: String!, $public_key: String!, $name: String) {
-    createAccount(token: $token, public_key: $public_key, name: $name) {
+export const CREATE_ACCOUNT_MUTATION = (includeName = true) => gql`
+  mutation ($token: String!, $public_key: String! ${
+    includeName ? ', $name: String' : ''
+  }) {
+    createAccount(token: $token, public_key: $public_key ${
+      includeName ? ', name: $name' : ''
+    }) {
       account
     }
   }

--- a/webapp/src/routes/Faucet/index.js
+++ b/webapp/src/routes/Faucet/index.js
@@ -30,7 +30,7 @@ const Faucet = () => {
   const [createAccountValues, setCreateAccountValues] = useState({})
   const [transferTokensTransaction, setTransferTokensTransaction] = useState('')
   const [createFaucetAccount, { loading: loadingCreateAccount }] = useMutation(
-    CREATE_ACCOUNT_MUTATION( eosConfig.networkName !== 'ultra-testnet' ),
+    CREATE_ACCOUNT_MUTATION(eosConfig.networkName !== 'ultra-testnet'),
   )
   const [transferFaucetTokens, { loading: loadingTransferFaucetTokens }] =
     useMutation(TRANFER_FAUCET_TOKENS_MUTATION)
@@ -52,6 +52,14 @@ const Faucet = () => {
       return
     }
 
+    if (!isValidAccountName(createAccountValues.accountName)) {
+      showMessage({
+        type: 'error',
+        content: 'Please enter a valid account name',
+      })
+      return
+    }
+
     try {
       const {
         data: {
@@ -61,7 +69,7 @@ const Faucet = () => {
         variables: {
           token: reCaptchaToken,
           public_key: createAccountValues.publicKey,
-          name: createAccountValues.accountName
+          name: createAccountValues.accountName,
         },
       })
 
@@ -74,10 +82,9 @@ const Faucet = () => {
         ),
       })
     } catch (err) {
-      const errorMessage = err.message.replace('GraphQL error:','').replace(
-        'assertion failure with message: ',
-        '',
-      )
+      const errorMessage = err.message
+        .replace('GraphQL error:', '')
+        .replace('assertion failure with message: ', '')
 
       showMessage({
         type: 'error',
@@ -93,6 +100,14 @@ const Faucet = () => {
     const reCaptchaToken = await executeRecaptcha?.('submit')
 
     if (!reCaptchaToken || !account) return
+
+    if (!isValidAccountName(account)) {
+      showMessage({
+        type: 'error',
+        content: 'Please enter a valid account name',
+      })
+      return
+    }
 
     try {
       const result = await transferFaucetTokens({
@@ -131,7 +146,7 @@ const Faucet = () => {
     setAccount('')
   }
 
-  const isValidName = name => {
+  const isValidAccountName = name => {
     const regex = /^[.12345abcdefghijklmnopqrstuvwxyz]+$/i
 
     return name?.length < 13 && regex.test(name)
@@ -173,7 +188,7 @@ const Faucet = () => {
                         ...{ accountName: e.target.value },
                       })
                     }
-                    error={!isValidName(createAccountValues.accountName)}
+                    error={!isValidAccountName(createAccountValues.accountName)}
                     required
                   />
                 </div>
@@ -212,7 +227,8 @@ const Faucet = () => {
                   variant="outlined"
                   value={account}
                   onChange={(e) => setAccount(e.target.value)}
-                  error={!isValidName(account)}
+                  error={!isValidAccountName(account)}
+                  required
                 />
               </div>
               <div>

--- a/webapp/src/routes/Faucet/index.js
+++ b/webapp/src/routes/Faucet/index.js
@@ -30,7 +30,7 @@ const Faucet = () => {
   const [createAccountValues, setCreateAccountValues] = useState({})
   const [transferTokensTransaction, setTransferTokensTransaction] = useState('')
   const [createFaucetAccount, { loading: loadingCreateAccount }] = useMutation(
-    CREATE_ACCOUNT_MUTATION,
+    CREATE_ACCOUNT_MUTATION( eosConfig.networkName !== 'ultra-testnet' ),
   )
   const [transferFaucetTokens, { loading: loadingTransferFaucetTokens }] =
     useMutation(TRANFER_FAUCET_TOKENS_MUTATION)
@@ -39,14 +39,17 @@ const Faucet = () => {
   const createAccount = async () => {
     const reCaptchaToken = await executeRecaptcha?.('submit')
 
-    if (eosConfig.networkName === 'libre-testnet') {
-      if (
-        !reCaptchaToken ||
-        (!createAccountValues.publicKey && !createAccountValues.accountName)
-      )
-        return
-    } else {
-      if (!reCaptchaToken || !createAccountValues.publicKey) return
+    if (
+      !reCaptchaToken ||
+      !createAccountValues.publicKey ||
+      (eosConfig.networkName !== 'ultra-testnet' &&
+        !createAccountValues.accountName)
+    ) {
+      showMessage({
+        type: 'error',
+        content: 'Fill out the fields to create an account',
+      })
+      return
     }
 
     try {
@@ -58,7 +61,7 @@ const Faucet = () => {
         variables: {
           token: reCaptchaToken,
           public_key: createAccountValues.publicKey,
-          name: createAccountValues.accountName || '',
+          name: createAccountValues.accountName
         },
       })
 
@@ -71,8 +74,8 @@ const Faucet = () => {
         ),
       })
     } catch (err) {
-      const errorMessage = err.message.replace(
-        'GraphQL error: assertion failure with message: ',
+      const errorMessage = err.message.replace('GraphQL error:','').replace(
+        'assertion failure with message: ',
         '',
       )
 
@@ -128,6 +131,12 @@ const Faucet = () => {
     setAccount('')
   }
 
+  const isValidName = name => {
+    const regex = /^[.12345abcdefghijklmnopqrstuvwxyz]+$/i
+
+    return name?.length < 13 && regex.test(name)
+  }
+
   return (
     <div className={classes.test}>
       <div className={classes.card}>
@@ -147,9 +156,11 @@ const Faucet = () => {
                       ...{ publicKey: e.target.value },
                     })
                   }
+                  error={!createAccountValues.publicKey}
+                  required
                 />
               </div>
-              {eosConfig.networkName === 'libre-testnet' && (
+              {eosConfig.networkName !== 'ultra-testnet' && (
                 <div>
                   <TextField
                     key="action-field-issue-tokens"
@@ -162,6 +173,8 @@ const Faucet = () => {
                         ...{ accountName: e.target.value },
                       })
                     }
+                    error={!isValidName(createAccountValues.accountName)}
+                    required
                   />
                 </div>
               )}
@@ -195,10 +208,11 @@ const Faucet = () => {
               <div>
                 <TextField
                   key="action-field-issue-tokens"
-                  label={`Account (500 ${eosConfig.tokenSymbol})`}
+                  label={`${t('account')} (500 ${eosConfig.tokenSymbol})`}
                   variant="outlined"
                   value={account}
                   onChange={(e) => setAccount(e.target.value)}
+                  error={!isValidName(account)}
                 />
               </div>
               <div>


### PR DESCRIPTION
### Fix create account in faucet page

### What does this PR do?

- Resolve #1200
- Resolve #1224
- To avoid the server error wait a second after creating the account to search for the public key through the `/v1/chain/get_accounts_by_authorizers`
- Don't include name in the query when is ultra testnet to resolve `input.name is not allowed to be empty`
- Add visual feedback when the account name is invalid

### Steps to test

1. Run the project locally 
2. Go to faucet page
3. Try to create an account

![imagen](https://github.com/edenia/antelope-tools/assets/66583677/81c9c2cf-aa12-405f-afaf-d4e5307f41b5)
