### PR TITLE
fix(webapp): use UTC to check if endpoint is outdated

### DIFF
--- a/webapp/src/utils/eosapi.js
+++ b/webapp/src/utils/eosapi.js
@@ -30,7 +30,11 @@ const callEosApi = async method => {
       const headBlockTime = response.head_block_time
 
       if (headBlockTime) {
-        const diffBlockTimems = new Date() - new Date(headBlockTime)
+        const nowUTC = new Date()
+
+        nowUTC.setMinutes(nowUTC.getMinutes() + nowUTC.getTimezoneOffset())
+
+        const diffBlockTimems = nowUTC - new Date(headBlockTime)
 
         if (diffBlockTimems > eosConfig.syncToleranceInterval) {
           throw new Error(`The endpoint ${eosApi.endpoint} is outdated`)


### PR DESCRIPTION
### Fix endpoints error

### What does this PR do?

- Resolve #1261 
- Set the date offset to zero to fix the calculation that determines if the endpoint information is out of date, which was causing the error: `Each endpoint failed when trying to execute the function`

### Steps to test

1. Run the project locally
2. Go to main page
3. Check the data