### PR TITLE
Fix/historic transactions error 1279

### DIFF
--- a/hapi-evm/src/services/transactions.service.ts
+++ b/hapi-evm/src/services/transactions.service.ts
@@ -16,8 +16,8 @@ export const getTransactions = async (range: string) => {
   const [rows] = await sequelizeUtil.sequelize.query(`
     WITH interval AS (
       SELECT generate_series(
-        date_trunc('${granularity}', now()) - '${range}'::interval,
-        date_trunc('${granularity}', now()),
+        date_trunc('${granularity}', (now() - '00:30:00'::interval)) - '${range}'::interval,
+        date_trunc('${granularity}', (now() - '00:30:00'::interval)),
         '1 ${granularity}'::interval
       ) AS value
     )

--- a/hapi/src/services/transactions.service.js
+++ b/hapi/src/services/transactions.service.js
@@ -12,10 +12,10 @@ const getTransactions = async (range = '3 Hours') => {
     )
 
     SELECT
-      interval.value as datetime,
-      avg(block_history.transactions_length)::integer as transactions_count,
-      avg(block_history.cpu_usage)::numeric(5,2) as cpu,
-      avg(block_history.net_usage)::numeric(6,3) as net
+      interval.value AS datetime,
+      SUM(block_history.transactions_length)::integer AS transactions_count,
+      AVG(block_history.cpu_usage)::numeric(5,2) AS cpu,
+      AVG(block_history.net_usage)::numeric(6,3) AS net
     FROM
       interval
     LEFT JOIN 

--- a/webapp/src/routes/EVMDashboard/useEVMstate.js
+++ b/webapp/src/routes/EVMDashboard/useEVMstate.js
@@ -168,7 +168,9 @@ const useEVMState = (theme, t) => {
 
   useEffect(() => {
     if (transactionsData?.transactions) {
-      const data = transactionsData?.transactions.map((transaction) => ({
+      setPause(true)
+
+      const data = transactionsData?.transactions.map(transaction => ({
         name: moment(transaction.datetime)?.format('ll'),
         gas: transaction.avg_gas_used || 0,
         y: parseInt(transaction.transactions_count) || 0,

--- a/webapp/src/routes/Home/TransactionInfo.js
+++ b/webapp/src/routes/Home/TransactionInfo.js
@@ -28,7 +28,7 @@ const TransactionInfo = ({ t, startTrackingInfo, stopTrackingInfo }) => {
   ])
   const [option, setOption] = useState(options[0])
   const [pause, setPause] = useState(false)
-  const [getTransactionHistory, { data, loading }] = useLazyQuery(
+  const [getTransactionHistory, { data: transactionsData , loading }] = useLazyQuery(
     TRANSACTION_QUERY,
     { fetchPolicy: 'network-only' },
   )
@@ -90,57 +90,41 @@ const TransactionInfo = ({ t, startTrackingInfo, stopTrackingInfo }) => {
       },
     })
     // eslint-disable-next-line
-  }, [option, getTransactionHistory])
+  }, [option, theme.palette, getTransactionHistory])
 
   useEffect(() => {
     if (option === option[0]) return
 
-    if (!data?.transactions.length) {
+    if (!transactionsData?.transactions.length) {
       setGraphicData([])
       return
     }
 
-    const { trxPerBlock, trxPerSecond } = data.transactions.reduce(
-      (history, transactionHistory) => {
-        history.trxPerBlock.push({
-          name: moment(transactionHistory.datetime)?.format('ll'),
-          cpu: transactionHistory.cpu || 0,
-          net: transactionHistory.net || 0,
-          y: transactionHistory.transactions_count || 0,
-          x: new Date(transactionHistory.datetime).getTime(),
+    const data = transactionsData.transactions.map(
+      transaction => 
+        ({
+          name: moment(transaction.datetime)?.format('ll'),
+          cpu: transaction.cpu || 0,
+          net: transaction.net || 0,
+          y: transaction.transactions_count || 0,
+          x: new Date(transaction.datetime).getTime(),
         })
-
-        history.trxPerSecond.push({
-          name: moment(transactionHistory.datetime)?.format('ll'),
-          cpu: transactionHistory.cpu / 2 || 0,
-          net: transactionHistory.net / 2 || 0,
-          y: transactionHistory.transactions_count * 2 || 0,
-          x: new Date(transactionHistory.datetime).getTime(),
-        })
-
-        return history
-      },
-      { trxPerBlock: [], trxPerSecond: [] },
     )
 
     setGraphicData([
       {
-        name: t('average') + ' ' + t('transactionsPerSecond'),
+        name: t('transactions'),
         color: theme.palette.secondary.main,
-        data: trxPerSecond,
-      },
-      {
-        name: t('average') + ' ' + t('transactionsPerBlock'),
-        color: theme.palette.tertiary.main,
-        data: trxPerBlock,
+        data
       },
     ])
     // eslint-disable-next-line
-  }, [data, t])
+  }, [transactionsData, theme.palette, t])
 
   return (
     <TransactionsChartContainer 
       title={t('transactions')}
+      ariaLabel="Transactions chart select"
       isPaused={pause}
       loading={loading}
       handlePause={() => {


### PR DESCRIPTION
### Fix historic transactions error

### What does this PR do?

- Resolve #1279
- Use the sum of txs insead of the average
- Remove the avg per block and per second
- Use a gap of 30 minutes in the evm transactions query

### Steps to test

1. Run the project locally with the history enable
2. Go to main page
3. Select a range
4. Check the data

### Screenshots

**Block History**

![imagen](https://github.com/edenia/antelope-tools/assets/66583677/d3e3fb00-ad26-4698-9f53-6a79646b11d1)
