### PR TITLE
Chore/use key icon for account keys 1295

### DIFF
--- a/webapp/src/components/AccountInfo/index.js
+++ b/webapp/src/components/AccountInfo/index.js
@@ -9,6 +9,7 @@ import Accordion from '@mui/material/Accordion'
 import AccordionSummary from '@mui/material/AccordionSummary'
 import AccordionDetails from '@mui/material/AccordionDetails'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import KeyOutlinedIcon from '@mui/icons-material/KeyOutlined';
 
 import RicardianContract from '../RicardianContract'
 import ContractActions from '../ContractActions'
@@ -116,7 +117,7 @@ const AccountInfo = ({
       {!!info && (
         <>
           <div className={classes.boxHeaderCard}>
-            <div className="identicon">
+            <div className={`identicon ${classes.cardPadding}`}>
               <div className={classes.iconBorder}>
                 <Identicon
                   string={info.account_name || 'default'}
@@ -165,7 +166,7 @@ const AccountInfo = ({
                       <dt className={classes.keyItem}>
                         <Typography>{key.label}</Typography>
                         {key.value ? (
-                          <MoreInfoModal>
+                          <MoreInfoModal Icon={KeyOutlinedIcon}>
                             <Typography className={classes.keyLabel}>
                               {key.value}
                             </Typography>

--- a/webapp/src/components/AccountInfo/index.js
+++ b/webapp/src/components/AccountInfo/index.js
@@ -160,24 +160,22 @@ const AccountInfo = ({
                 {t('keys')}
               </Typography>
               <div className="keys">
-                <dl>
-                  {info.keys.map((key) => (
-                    <span key={`account-key-${key.label}`}>
-                      <dt className={classes.keyItem}>
-                        <Typography>{key.label}</Typography>
-                        {key.value ? (
-                          <MoreInfoModal Icon={KeyOutlinedIcon}>
-                            <Typography className={classes.keyLabel}>
-                              {key.value}
-                            </Typography>
-                          </MoreInfoModal>
-                        ) : (
-                          <p>-</p>
-                        )}
-                      </dt>
-                    </span>
-                  ))}
-                </dl>
+                {info.keys.map(key => (
+                  <span key={`account-key-${key.label}`}>
+                    <div className={classes.keyItem}>
+                      <Typography>{key.label}</Typography>
+                      {key.value ? (
+                        <MoreInfoModal Icon={KeyOutlinedIcon}>
+                          <Typography className={classes.keyLabel}>
+                            {key.value}
+                          </Typography>
+                        </MoreInfoModal>
+                      ) : (
+                        <p>-</p>
+                      )}
+                    </div>
+                  </span>
+                ))}
               </div>
             </div>
           </div>

--- a/webapp/src/components/AccountInfo/styles.js
+++ b/webapp/src/components/AccountInfo/styles.js
@@ -28,7 +28,9 @@ export default (theme) => ({
     display: 'flex',
     textTransform: 'capitalize',
     justifyContent: 'space-between',
+    alignItems: 'center',
     minWidth: '100px',
+    paddingTop: theme.spacing(1),
   },
   keyIcon: {
     marginRight: theme.spacing(1),
@@ -104,5 +106,10 @@ export default (theme) => ({
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
+  },
+  cardPadding: {
+    [theme.breakpoints.up('lg')]: {
+      paddingRight: theme.spacing(4),
+    },
   },
 })

--- a/webapp/src/components/AccountInfo/styles.js
+++ b/webapp/src/components/AccountInfo/styles.js
@@ -30,7 +30,13 @@ export default (theme) => ({
     justifyContent: 'space-between',
     alignItems: 'center',
     minWidth: '100px',
-    paddingTop: theme.spacing(1),
+    paddingTop: theme.spacing(2),
+    '& p': {
+      marginRight: theme.spacing(2),
+    },
+    '& p:first-child': {
+      minWidth: '80px',
+    },
   },
   keyIcon: {
     marginRight: theme.spacing(1),

--- a/webapp/src/components/ContractActions/index.js
+++ b/webapp/src/components/ContractActions/index.js
@@ -33,7 +33,7 @@ const ContractActions = ({ accountName, abi, onSubmitAction }) => {
       <FormControl variant="outlined" className={classes.formControl}>
         <Autocomplete
             id="actionName"
-            labelId="actionNameLabel"
+            labelid="actionNameLabel"
             options={actions}
             value={action}
             inputValue={action}

--- a/webapp/src/components/ContractActions/index.js
+++ b/webapp/src/components/ContractActions/index.js
@@ -2,10 +2,9 @@ import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { useTranslation } from 'react-i18next'
 import { makeStyles } from '@mui/styles'
-import MenuItem from '@mui/material/MenuItem'
-import Select from '@mui/material/Select'
+import Autocomplete from '@mui/material/Autocomplete'
 import FormControl from '@mui/material/FormControl'
-import InputLabel from '@mui/material/InputLabel'
+import TextField from '@mui/material/TextField'
 
 import ContractActionForm from '../ContractActionForm'
 
@@ -32,25 +31,24 @@ const ContractActions = ({ accountName, abi, onSubmitAction }) => {
   return (
     <div className={classes.formControl}>
       <FormControl variant="outlined" className={classes.formControl}>
-        <InputLabel id="actionNameLabel">{t('action')}</InputLabel>
-        <Select
-          labelId="actionNameLabel"
-          id="actionName"
-          value={action}
-          onChange={(event) => setAction(event.target.value)}
-          label={t('action')}
-        >
-          {actions.map((item) => (
-            <MenuItem key={`action-menu-item-${item}`} value={item}>
-              {item}
-            </MenuItem>
-          ))}
-        </Select>
+        <Autocomplete
+            id="actionName"
+            labelId="actionNameLabel"
+            options={actions}
+            value={action}
+            inputValue={action}
+            onChange={(_e, value) => setAction(value || '')}
+            onInputChange={(_e, value) => setAction(value || '')}
+            renderInput={params => (
+              <TextField {...params} label={t('action')} />
+            )}
+            noOptionsText={t('noOptions')}
+          />
       </FormControl>
 
       <ContractActionForm
         accountName={accountName}
-        action={action}
+        action={actions.find(element => element === action)}
         abi={abi}
         onSubmitAction={onSubmitAction}
       />

--- a/webapp/src/components/EndpointsTable/index.js
+++ b/webapp/src/components/EndpointsTable/index.js
@@ -87,6 +87,7 @@ const EndpointsTable = ({ producers, textLists }) => {
                       <MUITooltip title={t('linkToStats')} arrow>
                         <Link
                           aria-label={`Link to endpoints stats of ${producer.name}`}
+                          title={`${producer.name} endpoints stats`}
                           component={RouterLink}
                           state={{ producerId: producer.id }}
                           to="/endpoints-stats"

--- a/webapp/src/components/MoreInfoModal/index.js
+++ b/webapp/src/components/MoreInfoModal/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, memo } from 'react'
 import { makeStyles } from '@mui/styles'
 import { useTranslation } from 'react-i18next'
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
@@ -10,7 +10,7 @@ import styles from './styles'
 
 const useStyles = makeStyles(styles)
 
-const MoreInfoModal = ({ hideCloseButton, children }) => {
+const MoreInfoModal = ({ hideCloseButton, Icon, children }) => {
   const classes = useStyles()
   const { t } = useTranslation()
   const [anchorEl, setAnchorEl] = useState(null)
@@ -26,12 +26,21 @@ const MoreInfoModal = ({ hideCloseButton, children }) => {
   return (
     <>
       <MUITooltip title={t('moreInfo')} arrow placement="right">
-        <InfoOutlinedIcon
-          className={classes.clickableIcon}
-          onClick={(e) => {
-            handlePopoverOpen(e.target)
-          }}
-        />
+        {Icon ? (
+          <Icon
+            className={classes.clickableIcon}
+            onClick={(e) => {
+              handlePopoverOpen(e.target)
+            }}
+          />
+        ) : (
+          <InfoOutlinedIcon
+            className={classes.clickableIcon}
+            onClick={(e) => {
+              handlePopoverOpen(e.target)
+            }}
+          />
+        )}
       </MUITooltip>
       <Tooltip
         anchorEl={anchorEl}
@@ -45,8 +54,8 @@ const MoreInfoModal = ({ hideCloseButton, children }) => {
   )
 }
 
-Tooltip.defaultProps = {
+MoreInfoModal.defaultProps = {
   hideCloseButton: false,
 }
 
-export default MoreInfoModal
+export default memo(MoreInfoModal)

--- a/webapp/src/components/NodeCard/NodesCard.js
+++ b/webapp/src/components/NodeCard/NodesCard.js
@@ -6,6 +6,7 @@ import { makeStyles } from '@mui/styles'
 import CardHeader from '@mui/material/CardHeader'
 import CardContent from '@mui/material/CardContent'
 import Chip from '@mui/material/Chip'
+import KeyOutlinedIcon from '@mui/icons-material/KeyOutlined';
 import 'flag-icon-css/css/flag-icons.css'
 
 import ChipList from '../ChipList'
@@ -51,7 +52,7 @@ const NodesCard = ({ nodes }) => {
         {Object.keys(keys).map((key, i) => (
           <div key={i} className={classes.keysContainer}>
             <p className={classes.bold}>{key}:</p>
-            <MoreInfoModal>
+            <MoreInfoModal Icon={KeyOutlinedIcon}>
               <p className={classes.keys}>{keys[key]}</p>
             </MoreInfoModal>
           </div>

--- a/webapp/src/components/RicardianContract/index.js
+++ b/webapp/src/components/RicardianContract/index.js
@@ -35,12 +35,16 @@ const RicardianContract = ({ abi, hash }) => {
               onError={useDefaultLogo}
             />
             <div className={classes.boxText}>
-              <Typography color="primary" variant="h5">
-                {_title || name}
-              </Typography>
-              <Typography color="primary" variant="subtitle2">
-                {version}
-              </Typography>
+              {_title && name && (
+                <Typography color="primary" variant="h5">
+                  {_title || name}
+                </Typography>
+              )}
+              {version && (
+                <Typography color="primary" variant="subtitle2">
+                  {version}
+                </Typography>
+              )}
             </div>
           </div>
           <Divider className={classes.divider} />

--- a/webapp/src/components/Sidebar/SidebarCategory.js
+++ b/webapp/src/components/Sidebar/SidebarCategory.js
@@ -6,6 +6,7 @@ import ExpandMore from '@mui/icons-material/ExpandMore'
 import { Chip, ListItem as MuiListItem, ListItemText } from '@mui/material'
 import styled from 'styled-components'
 import { darken } from 'polished'
+import { eosConfig } from 'config'
 
 const Category = styled(MuiListItem)`
   font-weight: ${(props) => props.theme.typography.fontWeightRegular};
@@ -39,10 +40,23 @@ const SidebarCategory = ({
   showOnlyIcons,
   ...rest
 }) => {
-  if (showOnlyIcons) return <Category {...rest} aria-label={`Link to ${name}`}>{icon}</Category>
+  if (showOnlyIcons)
+    return (
+      <Category
+        {...rest}
+        aria-label={`Link to ${name}`}
+        title={`${eosConfig.networkLabel} ${name}`}
+      >
+        {icon}
+      </Category>
+    )
 
   return (
-    <Category {...rest}>
+    <Category
+      {...rest}
+      aria-label={`Link to ${name}`}
+      title={`${eosConfig.networkLabel} ${name}`}
+    >
       {icon}
       <ListItemText className={classes.categoryText}>{name}</ListItemText>
       {isCollapsable ? (

--- a/webapp/src/routes/BlockDistribution/index.js
+++ b/webapp/src/routes/BlockDistribution/index.js
@@ -103,11 +103,11 @@ const BlockDistribution = () => {
           </Typography>
           <div className={classes.formControl}>
             <FormControl variant="standard">
-              <InputLabel id="select-range-label">
+              <InputLabel htmlFor="select-range-label">
                 {t('timeFrame')}
               </InputLabel>
               <Select
-                labelid="select-range-label"
+                inputProps={{ id: 'select-range-label' }}
                 value={range}
                 onChange={(e) => setRange(e.target.value)}
                 fullWidth

--- a/webapp/src/routes/BlockDistribution/index.js
+++ b/webapp/src/routes/BlockDistribution/index.js
@@ -103,11 +103,11 @@ const BlockDistribution = () => {
           </Typography>
           <div className={classes.formControl}>
             <FormControl variant="standard">
-              <InputLabel id="demo-simple-select-label">
+              <InputLabel id="select-range-label">
                 {t('timeFrame')}
               </InputLabel>
               <Select
-                labelId="demo-simple-select-label"
+                labelid="select-range-label"
                 value={range}
                 onChange={(e) => setRange(e.target.value)}
                 fullWidth

--- a/webapp/src/routes/CPUBenchmark/index.js
+++ b/webapp/src/routes/CPUBenchmark/index.js
@@ -187,11 +187,11 @@ const CPUBenchmark = () => {
             {t('title')}
           </Typography>
           <FormControl variant="standard">
-            <InputLabel id="demo-simple-select-label">
+            <InputLabel id="select-range-label">
               {t('timeFrame')}
             </InputLabel>
             <Select
-              labelId="demo-simple-select-label"
+              labelid="select-range-label"
               value={range}
               onChange={event => setRange(event.target.value)}
               fullWidth

--- a/webapp/src/routes/CPUBenchmark/index.js
+++ b/webapp/src/routes/CPUBenchmark/index.js
@@ -187,11 +187,11 @@ const CPUBenchmark = () => {
             {t('title')}
           </Typography>
           <FormControl variant="standard">
-            <InputLabel id="select-range-label">
+            <InputLabel htmlFor="select-range-label">
               {t('timeFrame')}
             </InputLabel>
             <Select
-              labelid="select-range-label"
+              inputProps={{ id: 'select-range-label' }}
               value={range}
               onChange={event => setRange(event.target.value)}
               fullWidth

--- a/webapp/src/routes/MissedBlocks/index.js
+++ b/webapp/src/routes/MissedBlocks/index.js
@@ -119,11 +119,11 @@ const BlockDistribution = () => {
             {t('title')}
           </Typography>
           <FormControl variant="standard">
-            <InputLabel id="select-range-label">
+            <InputLabel htmlFor="select-range-label">
               {t('timeFrame')}
             </InputLabel>
             <Select
-              labelid="select-range-label"
+              inputProps={{ id: 'select-range-label' }}
               value={range}
               onChange={(e) => setRange(e.target.value)}
               fullWidth

--- a/webapp/src/routes/MissedBlocks/index.js
+++ b/webapp/src/routes/MissedBlocks/index.js
@@ -119,11 +119,11 @@ const BlockDistribution = () => {
             {t('title')}
           </Typography>
           <FormControl variant="standard">
-            <InputLabel id="demo-simple-select-label">
+            <InputLabel id="select-range-label">
               {t('timeFrame')}
             </InputLabel>
             <Select
-              labelId="demo-simple-select-label"
+              labelid="select-range-label"
               value={range}
               onChange={(e) => setRange(e.target.value)}
               fullWidth


### PR DESCRIPTION
### Add key icon for account keys and fix accessibility 

### What does this PR do?

- Resolve #1295
- Remove unneeded description list 
- Add titles to the links in the sidebar
- Use the autocomplete component to select the action

### Steps to test

1. Run the project locally
2. Go to accounts and nodes pages
3. Check the key icon

### Screenshots

![imagen](https://github.com/edenia/antelope-tools/assets/66583677/39c62ca2-6e76-4c8a-9ca6-87d53a9f6f5b)
![imagen](https://github.com/edenia/antelope-tools/assets/66583677/cb3e67b7-b232-4102-97a1-e6ad43255f54)
