### PR TITLE
chore(webapp): reduce the expiration of css and js files to seven days

### DIFF
--- a/webapp/nginx.conf
+++ b/webapp/nginx.conf
@@ -2,8 +2,8 @@ server {
   listen 80;
 
   location ~* ^/static/(css|js)/$ {
-    add_header Cache-Control "public, max-age=31536000";
-    expires 365d;
+    add_header Cache-Control "public, max-age=604800";
+    expires 7d;
   }
 
   location ~* ^/static/media/$ {


### PR DESCRIPTION
### Reduce the max age value to 7 days

### What does this PR do?

- Reduce the amount of time that css and js files are considered fresh to try to solve the problem of loading an old version of the app from the cache
