### PR TITLE
chore(webapp): include the connect wallet button only on necessary pages

### DIFF
--- a/webapp/src/components/ContractTables/index.js
+++ b/webapp/src/components/ContractTables/index.js
@@ -234,8 +234,8 @@ const ContractTables = ({
               color="primary"
               className={classes.refreshButton}
               onClick={() => handleSubmit()}
+              startIcon={<RefreshIcon />}
             >
-              <RefreshIcon />
               {t('refreshData')}
             </Button>
           )}

--- a/webapp/src/components/Header/index.js
+++ b/webapp/src/components/Header/index.js
@@ -1,7 +1,12 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, lazy, Suspense } from 'react'
 import PropTypes from 'prop-types'
 import { makeStyles } from '@mui/styles'
-import { Hidden, Menu, MenuItem, AppBar, IconButton } from '@mui/material'
+import Hidden from '@mui/material/Hidden'
+import Menu from '@mui/material/Menu'
+import MenuItem from '@mui/material/MenuItem'
+import AppBar from '@mui/material/AppBar'
+import IconButton from '@mui/material/IconButton'
+import Skeleton from '@mui/material/Skeleton'
 import Button from '@mui/material/Button'
 import Toolbar from '@mui/material/Toolbar'
 import MenuIcon from '@mui/icons-material/Menu'
@@ -10,8 +15,9 @@ import { useTranslation } from 'react-i18next'
 import moment from 'moment'
 import 'moment/locale/es'
 
-import AuthButton from './AuthButton'
 import styles from './styles'
+
+const AuthButton = lazy(() => import('./AuthButton'))
 
 const useStyles = makeStyles(styles)
 
@@ -72,9 +78,7 @@ const LanguageMenu = () => {
         onClick={toggleMenu}
         className={classes.btnLanguage}
       >
-        <span>
-          {currentLanguaje.toUpperCase()}
-        </span>
+        <span>{currentLanguaje.toUpperCase()}</span>
       </Button>
       <Menu
         id="menu-appbar"
@@ -96,7 +100,7 @@ const LanguageMenu = () => {
   )
 }
 
-const Header = ({ onDrawerToggle }) => {
+const Header = ({ onDrawerToggle, useConnectWallet = false }) => {
   const classes = useStyles()
 
   return (
@@ -118,7 +122,15 @@ const Header = ({ onDrawerToggle }) => {
           </div>
           <div className={classes.userBox}>
             <LanguageMenu />
-            <AuthButton classes={classes} />
+            {useConnectWallet && (
+              <Suspense
+                fallback={
+                  <Skeleton variant="rectangular" width={210} height={40} />
+                }
+              >
+                <AuthButton classes={classes} />
+              </Suspense>
+            )}
           </div>
         </div>
       </Toolbar>
@@ -128,6 +140,7 @@ const Header = ({ onDrawerToggle }) => {
 
 Header.propTypes = {
   onDrawerToggle: PropTypes.func,
+  useConnectWallet: PropTypes.bool,
 }
 
 export default Header

--- a/webapp/src/language/es.lacchain.json
+++ b/webapp/src/language/es.lacchain.json
@@ -12,7 +12,7 @@
     "/node-config>sidebar": "Configuración de nodo",
     "/node-config>title": "Configuración de nodo - Panel de red de {{networkName}}",
     "/node-config>heading": "Configurar un nuevo nodo",
-    "/ricardian-contract>sidebar": "Acuerdo de Nodos Validadores - Panel de red de {{networkName}}",
+    "/ricardian-contract>sidebar": "Acuerdo de Nodos Validadores",
     "/ricardian-contract>heading": "",
     "/entities>moreDescription": "Una lista de entidades que forman parte de la red. Pueden ser entidades socias o no socias.",
     "/lacchain/network>moreDescription": "Una representación visual de los nodos actuales de la red.",

--- a/webapp/src/layouts/Dashboard.js
+++ b/webapp/src/layouts/Dashboard.js
@@ -83,6 +83,7 @@ const Dashboard = ({ children }) => {
         pageTitle: t(`${pathName}>title`, {
           networkName: eosConfig.networkLabel,
         }),
+        useConnectWallet: Boolean(route.useConnectWallet)
       })
     } else {
       setRouteName(INIT_VALUES)
@@ -104,7 +105,7 @@ const Dashboard = ({ children }) => {
         }
       />
       <div className={classes.header}>
-        <Header onDrawerToggle={handleDrawerToggle} />
+        <Header onDrawerToggle={handleDrawerToggle} useConnectWallet={routeName.useConnectWallet} />
       </div>
       <div
         className={classes.drawer}

--- a/webapp/src/routes/index.js
+++ b/webapp/src/routes/index.js
@@ -13,6 +13,7 @@ import {
   BarChart as BarChartIcon,
 } from 'react-feather'
 import QueryStatsIcon from '@mui/icons-material/QueryStats'
+import GavelIcon from '@mui/icons-material/Gavel';
 
 import { eosConfig, generalConfig } from '../config'
 import {
@@ -149,7 +150,7 @@ const defaultRoutes = [
   },
   {
     name: 'ricardianContract',
-    icon: <InfoIcon />,
+    icon: <GavelIcon />,
     component: RicardianContract,
     path: '/ricardian-contract',
     exact: true,
@@ -175,6 +176,7 @@ const defaultRoutes = [
     icon: <UserIcon />,
     component: Accounts,
     path: '/accounts',
+    useConnectWallet: true,
     exact: true,
   },
   {
@@ -182,6 +184,7 @@ const defaultRoutes = [
     icon: <BPJsonSvg />,
     component: BPJson,
     path: '/bpjson',
+    useConnectWallet: true,
     exact: true,
   },
 ]
@@ -266,7 +269,7 @@ const lacchainRoutes = [
   },
   {
     name: 'ricardianContract',
-    icon: <InfoIcon />,
+    icon: <GavelIcon />,
     component: RicardianContract,
     path: '/ricardian-contract',
     exact: true,
@@ -277,6 +280,7 @@ const lacchainRoutes = [
     icon: <UserIcon />,
     component: Accounts,
     path: '/accounts',
+    useConnectWallet: true,
     exact: true,
   },
   {
@@ -284,6 +288,7 @@ const lacchainRoutes = [
     icon: <SlidersIcon />,
     component: LacchainManagement,
     path: '/management',
+    useConnectWallet: true,
     exact: true,
   },
   {
@@ -291,6 +296,7 @@ const lacchainRoutes = [
     icon: <ConfigSvg />,
     component: LacchainNodeConfig,
     path: '/node-config',
+    useConnectWallet: true,
     exact: true,
   },
 ]


### PR DESCRIPTION
###  Include the connect wallet button only on necessary pages

### What does this PR do?

- Resolve #1326
- Resolve #1335 

### Steps to test

1. Run the project locally
2. Go to Accounts & Contracts or BP JSON Generator Page and see the button
3. Go to another page and see that the button does not appear.

### Screenshots

![imagen](https://github.com/edenia/antelope-tools/assets/66583677/913881cd-175e-4fec-928f-794befa02976)
![imagen](https://github.com/edenia/antelope-tools/assets/66583677/f59552b9-7d80-4b0a-b641-ffb414527f9c)
![imagen](https://github.com/edenia/antelope-tools/assets/66583677/0160289a-4d49-40ac-9964-ceb62e6af888)
![imagen](https://github.com/edenia/antelope-tools/assets/66583677/5be873d1-f716-4c23-a641-8c3ed7ac50cd)

