### PR TITLE
Fix/adjust links in geo map 1348

### DIFF
--- a/webapp/src/components/GeoMap/CountryMap.js
+++ b/webapp/src/components/GeoMap/CountryMap.js
@@ -18,9 +18,8 @@ const ClusterMap = ({ data, map, mapCode }) => {
   const navigate = useNavigate()
   const myRef = useRef()
 
-  const find2DPointDistance = (p0, p1) => {
-    return Math.sqrt((p0.x - p1.x) ** 2 + (p0.y - p1.y) ** 2)
-  }
+  const find2DPointDistance = (p0, p1) =>
+    Math.sqrt((p0.x - p1.x) ** 2 + (p0.y - p1.y) ** 2)
 
   const getNew2DPoint = (p0, p1, distance) => ({
     x: (distance + 1) * p1.x + -distance * p0.x,
@@ -29,32 +28,17 @@ const ClusterMap = ({ data, map, mapCode }) => {
 
   const setupMapData = useCallback(
     (data, map, mapCode = '') => {
-
-      data = data.reduce((result, current) => {
-        if (result.every(node => node.name !== current.name)) {
-          result.push(current)
-        }
-
-        return result
-      }, [])
-
       for (const index in data) {
-        const node = data[index]
-        const point = { x: node.lon, y: node.lat }
+        const currentPoint = { x: data[index].lon, y: data[index].lat }
 
         for (const auxIndex in data) {
           if (parseInt(index) >= parseInt(auxIndex)) continue
 
           const auxPoint = { x: data[auxIndex].lon, y: data[auxIndex].lat }
-
-          const distance = find2DPointDistance(point,auxPoint)
+          const distance = find2DPointDistance(currentPoint, auxPoint)
 
           if (distance < 0.5) {
-            const newPoint = getNew2DPoint(
-              point,
-              auxPoint,
-              distance,
-            )
+            const newPoint = getNew2DPoint(currentPoint, auxPoint, distance)
 
             data[auxIndex].lon = newPoint.x
             data[auxIndex].lat = newPoint.y

--- a/webapp/src/components/GeoMap/index.js
+++ b/webapp/src/components/GeoMap/index.js
@@ -87,9 +87,16 @@ const GeoMap = ({ data }) => {
     if (!mapSelected) return
 
     const getMap = async () => {
-      const mapDataSelected = data.filter(
-        ({ country }) => country === mapSelected.toUpperCase(),
-      )
+      const mapDataSelected = data.reduce((result, current) => {
+        if (
+          current.country === mapSelected.toUpperCase() &&
+          result.every(node => node.name !== current.name)
+        ) {
+          result.push(current)
+        }
+
+        return result
+      }, [])
       const { data: mapRes } = await axios.get(
         `${generalConfig.highchartsMapURL}${mapSelected}/${mapSelected}-all.geo.json`,
       )

--- a/webapp/src/components/GeoMap/styles.js
+++ b/webapp/src/components/GeoMap/styles.js
@@ -9,6 +9,9 @@ export default (theme) => ({
     height: '100vh',
     '& a': {
       color: theme.palette.primary.main
+    },
+    '& .highcharts-label': {
+      opacity: '1 !important',
     }
   },
 })

--- a/webapp/src/routes/Home/styles.js
+++ b/webapp/src/routes/Home/styles.js
@@ -22,5 +22,14 @@ export default (theme) => ({
       width: '100%',
       marginBottom: '10px',
     },
+    '& > .MuiCard-root': {
+      height: '100%',
+      '& :nth-child(2)': {
+        [theme.breakpoints.up('lg')]: {
+          position: 'relative',
+          top: 'calc(50% - 232px)',
+        },
+      }
+    }
   },
 })


### PR DESCRIPTION
### Adjust links in Nodes Distribution page

### What does this PR do?

- Resolve #1348
- In order to avoid duplicated links or labels above others:
  -  Enable zoom 
  -  Display only a node per producer because it is a link to BP Profile
  -  Move a little those nodes too close to another one
- Set same height to transactions live chart in the main page

### Steps to test

1. Run the project locally
2. Go to nodes distribution page
3. Click on several countries
4. Check every link is reachable

### Screenshots

# Nodes Distribution Before

![imagen](https://github.com/edenia/antelope-tools/assets/66583677/9eeceffd-207e-4906-9702-a8c167ad6bba)
![imagen](https://github.com/edenia/antelope-tools/assets/66583677/0af26493-8400-44bc-8108-83d2188a19e5)
![imagen](https://github.com/edenia/antelope-tools/assets/66583677/a5f31a7b-c375-471d-926d-d7fc99a0c6ac)

# Nodes Distribution Now

![imagen](https://github.com/edenia/antelope-tools/assets/66583677/cf7a5238-eaa7-4d34-89f3-8819353c47e9)
![imagen](https://github.com/edenia/antelope-tools/assets/66583677/7431d9dc-199f-4501-8cf8-ad3af77c9a8e)
![imagen](https://github.com/edenia/antelope-tools/assets/66583677/d25d9ec3-b200-4fed-9f09-06b931e728f7)
![imagen](https://github.com/edenia/antelope-tools/assets/66583677/71ed2507-0887-40b7-b221-2ad6728d8c81)

# Main page

![imagen](https://github.com/edenia/antelope-tools/assets/66583677/89577380-f080-41f3-a906-63a97f932ec6)

