### PR TITLE
Fix/syncing old blocks 1385

### DIFF
--- a/hapi-evm/src/models/block/queries.ts
+++ b/hapi-evm/src/models/block/queries.ts
@@ -38,6 +38,7 @@ const internal_get = async <T>(
   // such as limit, order, etc
   where: object,
   order: object | null,
+  limit: number | null,
   attributes: string,
   operation?: string
 ): Promise<T> => {
@@ -45,7 +46,7 @@ const internal_get = async <T>(
       ${type} (${parameters}) {
         ${table}${
           operation ? `_${operation}` : ''
-        }(where: $where, order_by: $order) {
+        }(where: $where, order_by: $order, limit: $limit) {
           ${attributes}
         }
       }
@@ -53,7 +54,8 @@ const internal_get = async <T>(
 
   return await coreUtil.hasura.default.request<T>(query, {
     where,
-    order
+    order,
+    limit
   })
 }
 
@@ -61,12 +63,13 @@ export const exist = async (hashOrNumber: string | number) => {
   const result = await internal_get<BlockAggregateResponse>(
     'query',
     'evm_block',
-    '$where: evm_block_bool_exp!, $order: [evm_block_order_by!]',
+    '$where: evm_block_bool_exp!, $order: [evm_block_order_by!], $limit: Int',
     {
       [typeof hashOrNumber === 'string' ? 'hash' : 'number']: {
         _eq: hashOrNumber
       }
     },
+    null,
     null,
     'aggregate { count }',
     'aggregate'
@@ -83,9 +86,10 @@ const get = async (
   const result = await internal_get<BlockResponse>(
     'query',
     'evm_block',
-    '$where: evm_block_bool_exp!, $order: [evm_block_order_by!]',
+    '$where: evm_block_bool_exp!, $order: [evm_block_order_by!], $limit: Int',
     where,
     order,
+    !many ? 1 : null,
     'hash, gas_used, transactions, number, timestamp'
   )
 

--- a/hapi-evm/src/models/historical-stats/queries.ts
+++ b/hapi-evm/src/models/historical-stats/queries.ts
@@ -88,9 +88,8 @@ export const getState = async () => {
       }
     }
   `
-  const data = await coreUtil.hasura.default.request<HistoricalStatsResponse>(
-    query
-  )
+  const data =
+    await coreUtil.hasura.default.request<HistoricalStatsResponse>(query)
 
   if (!data.evm_historical_stats.length) {
     return defaultHistoricalStats

--- a/hapi-evm/src/models/param/interfaces.ts
+++ b/hapi-evm/src/models/param/interfaces.ts
@@ -2,4 +2,5 @@ export interface Param {
   id: string
   next_block: number
   is_synced: boolean
+  complete_at: number
 }

--- a/hapi-evm/src/models/param/queries.ts
+++ b/hapi-evm/src/models/param/queries.ts
@@ -16,10 +16,15 @@ interface ParamOneResponse {
 const defaultParam = {
   id: '00000000-0000-0000-0000-000000000000',
   nextBlock: 0,
-  isSynced: false
+  isSynced: false,
+  completeAt: null
 }
 
-export const save = async (nextBlock: number, isSynced: boolean = false) => {
+export const save = async (
+  nextBlock: number,
+  isSynced: boolean = false,
+  completeAt: number
+) => {
   const mutation = gql`
     mutation ($payload: evm_param_insert_input!) {
       insert_evm_param_one(object: $payload) {
@@ -33,7 +38,8 @@ export const save = async (nextBlock: number, isSynced: boolean = false) => {
     {
       payload: {
         next_block: nextBlock,
-        is_synced: isSynced
+        is_synced: isSynced,
+        complete_at: completeAt
       }
     }
   )
@@ -44,7 +50,8 @@ export const save = async (nextBlock: number, isSynced: boolean = false) => {
 export const update = async (
   id: string,
   nextBlock: number,
-  isSynced: boolean = false
+  isSynced: boolean = false,
+  completeAt: number
 ) => {
   const mutation = gql`
     mutation ($id: uuid!, $payload: evm_param_set_input) {
@@ -60,7 +67,8 @@ export const update = async (
     id,
     payload: {
       next_block: nextBlock,
-      is_synced: isSynced
+      is_synced: isSynced,
+      complete_at: completeAt
     }
   })
 }
@@ -75,6 +83,7 @@ export const getState = async () => {
         id
         next_block
         is_synced
+        complete_at
       }
     }
   `
@@ -89,21 +98,23 @@ export const getState = async () => {
   return {
     id: state.id,
     nextBlock: state.next_block,
-    isSynced: state.is_synced
+    isSynced: state.is_synced,
+    completeAt: state.complete_at
   }
 }
 
 export const saveOrUpdate = async (
   nextBlock: number,
-  isSynced: boolean
+  isSynced: boolean,
+  completeAt: number
 ): Promise<void> => {
   const currentState = await getState()
 
   if (currentState === defaultParam) {
-    await save(nextBlock, isSynced)
+    await save(nextBlock, isSynced, completeAt)
 
     return
   }
 
-  await update(currentState.id, nextBlock, isSynced)
+  await update(currentState.id, nextBlock, isSynced, completeAt)
 }

--- a/hapi-evm/src/models/transaction/queries.ts
+++ b/hapi-evm/src/models/transaction/queries.ts
@@ -30,19 +30,23 @@ const internal_get = async <T>(
   // TODO: not only accept where but also additional content
   // such as limit, order, etc
   where: object,
+  limit: number | null,
   attributes: string,
   operation?: string
 ): Promise<T> => {
   const gqlObj = gql`
       ${type} (${parameters}) {
-        ${table}${operation ? `_${operation}` : ''}(where: $where) {
+        ${table}${
+          operation ? `_${operation}` : ''
+        }(where: $where, limit: $limit) {
           ${attributes}
         }
       }
     `
 
   return await coreUtil.hasura.default.request<T>(gqlObj, {
-    where
+    where,
+    limit
   })
 }
 
@@ -50,8 +54,9 @@ export const exist = async (hash: string) => {
   const result = await internal_get<TransactionAggregateResponse>(
     Operation.query,
     'evm_transaction',
-    '$where: evm_transaction_bool_exp!',
+    '$where: evm_transaction_bool_exp!, $limit: Int',
     { hash: { _eq: hash } },
+    null,
     'aggregate { count }',
     'aggregate'
   )
@@ -63,9 +68,10 @@ const get = async (where: object, many = false) => {
   const result = await internal_get<TransactionResponse>(
     'query',
     'evm_transaction',
-    '$where: evm_transaction_bool_exp!',
+    '$where: evm_transaction_bool_exp!, $limit: Int',
     where,
-    'hash, gas_used, transactions, number, timestamp'
+    !many ? 1 : null,
+    'hash, block_hash, block_number, gas, gas_price'
   )
 
   return many ? result.evm_transaction : result.evm_transaction[0]

--- a/hasura/migrations/default/1699546042430_alter_table_evm_param_add_column_complete_at/down.sql
+++ b/hasura/migrations/default/1699546042430_alter_table_evm_param_add_column_complete_at/down.sql
@@ -1,0 +1,4 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- alter table "evm"."param" add column "complete_at" numeric
+--  null;

--- a/hasura/migrations/default/1699546042430_alter_table_evm_param_add_column_complete_at/up.sql
+++ b/hasura/migrations/default/1699546042430_alter_table_evm_param_add_column_complete_at/up.sql
@@ -1,0 +1,2 @@
+alter table "evm"."param" add column "complete_at" numeric
+ null;


### PR DESCRIPTION
### Use the first inserted block to check when synchronization should stop.

### What does this PR do?

- Resolve #1385
- Persist the first inserted block to 
   - Make the comparision with the next block instead of check if it is already in the DB
   - The first block could be deleted by the service to remove old blocks
- Limit the query to get the last block in the DB
- Use an array of promises to synchronize old blocks
   

### Steps to test

1. Run the project locally with EVM configuration
2. Check the service to synchronize old blocks

