### PR TITLE
chore(hapi-evm): reduce the number of old blocks sync per round

### DIFF
--- a/hapi-evm/src/services/block.service.ts
+++ b/hapi-evm/src/services/block.service.ts
@@ -139,7 +139,7 @@ const syncOldBlocks = async (): Promise<void> => {
     console.log(
       `🚦 Syncing blocks behind, pending ${nextBlockToNumber - nextBlock} `
     )
-    blocksInserted = Math.min(100, nextBlockToNumber - nextBlock)
+    blocksInserted = Math.min(25, nextBlockToNumber - nextBlock)
     const blockPromises = []
     for (let index = 0; index < blocksInserted; index++) {
       blockPromises.push(syncFullBlock(nextBlock + index))


### PR DESCRIPTION
### Reduce the number of old blocks sync per round

### What does this PR do?

- Try to solve the issue related with the slow hasura speed cause by waiting for individual blocks inserts

### Steps to test

1. Run the project locally with evm configuration
2. Check the service for old block synchronization

