### PR TITLE
Perf/evm tx insertion and fix gas used

### DIFF
--- a/hapi-evm/src/models/transaction/queries.ts
+++ b/hapi-evm/src/models/transaction/queries.ts
@@ -96,8 +96,34 @@ export const add_or_modify = async (transaction: CappedTransaction) => {
   return data
 }
 
+export const add_or_modify_many = async (transactions: CappedTransaction[]) => {
+  const mutation = gql`
+    mutation ($evm_transactions: [evm_transaction_insert_input!]!) {
+      insert_evm_transaction(
+        objects: $evm_transactions
+        on_conflict: {
+          constraint: transaction_pkey
+          update_columns: [block_hash, block_number, gas, gas_price, hash]
+        }
+      ) {
+        affected_rows
+      }
+    }
+  `
+  const { insert_evm_transaction_one: data } =
+    await coreUtil.hasura.default.request<TransactionInsertOneResponse>(
+      mutation,
+      {
+        evm_transactions: transactions
+      }
+    )
+
+  return data
+}
+
 export default {
   exist,
   get,
-  add_or_modify
+  add_or_modify,
+  add_or_modify_many
 }

--- a/hapi-evm/src/services/block.service.ts
+++ b/hapi-evm/src/services/block.service.ts
@@ -86,8 +86,6 @@ const syncFullBlock = async (blockNumber: number | bigint) => {
 
   if (!block.transactions?.length) return
 
-  await incrementTotalTransactions(block.transactions?.length)
-
   const cappedTransactions = await Promise.all(
     cappedBlock.transactions.map(async (trxHash: TransactionHash) => {
       const trx: TransactionInfo = await web3.eth.getTransaction(
@@ -107,6 +105,7 @@ const syncFullBlock = async (blockNumber: number | bigint) => {
   )
 
   await transactionModel.queries.add_or_modify_many(cappedTransactions)
+  await incrementTotalTransactions(block.transactions?.length)
 }
 
 const incrementTotalTransactions = async (transactionsCount: number) => {


### PR DESCRIPTION
### Fix missing gas used data in blocks

### What does this PR do?

- Resolve #1389
- Use the transaction receipts to calculate the gas used by a block when it has transactions and no gas used
- Insert all transactions in a block using one query

### Steps to test

1. Run the project locally with eos evm configuration
2. Check in the DB that blocks with transactions have a gas used greater than zero

### Screenshots

![imagen](https://github.com/edenia/antelope-tools/assets/66583677/4c514f02-09ba-4556-84ab-6ea2a136903c)

