### PR TITLE
fix(webapp): improve page load speed for endpoints page

### DIFF
--- a/webapp/src/gql/producer.gql.js
+++ b/webapp/src/gql/producer.gql.js
@@ -135,8 +135,8 @@ export const NODES_BY_PRODUCER_SUBSCRIPTION = gql`
   }
 `
 
-export const NODES_SUBSCRIPTION = gql`
-  subscription ($offset: Int = 0, $limit: Int = 21, $where: producer_bool_exp) {
+const NODES_OPERATION = type => gql`
+  ${type} ($offset: Int = 0, $limit: Int = 21, $where: producer_bool_exp) {
     producers: producer(
       where: $where
       limit: $limit
@@ -171,8 +171,11 @@ export const NODES_SUBSCRIPTION = gql`
   }
 `
 
-export const ENDPOINTS_SUBSCRIPTION = gql`
-  subscription (
+export const NODES_SUBSCRIPTION = NODES_OPERATION('subscription')
+export const NODES_QUERY = NODES_OPERATION('query')
+
+const ENDPOINTS_OPERATION = type => gql`
+  ${type} (
     $offset: Int = 0
     $limit: Int = 21
     $where: producer_bool_exp
@@ -197,6 +200,9 @@ export const ENDPOINTS_SUBSCRIPTION = gql`
     }
   }
 `
+
+export const ENDPOINTS_SUBSCRIPTION = ENDPOINTS_OPERATION('subscription')
+export const ENDPOINTS_QUERY = ENDPOINTS_OPERATION('query')
 
 export const NODE_CPU_BENCHMARK = gql`
   query ($account: String) {

--- a/webapp/src/utils/is-same-object.js
+++ b/webapp/src/utils/is-same-object.js
@@ -1,0 +1,14 @@
+export const isTheSameObject = (obj1, obj2) => {
+  if (typeof obj1 === 'object' && typeof obj2 === 'object') {
+    if (Object.keys(obj1 || {}).length !== Object.keys(obj2 || {}).length)
+      return false
+
+    return Object.keys(obj1 || {}).every((key) => {
+      return isTheSameObject(obj1[key], obj2[key])
+    })
+  }
+
+  return obj1 === obj2
+}
+
+export default isTheSameObject


### PR DESCRIPTION
### Improve page load speed for endpoints page

### What does this PR do?

- Resolve #1383
- Use the onSubscriptionData instead of data object
- When the page loads queries the data and uses it in case the subscription is not available

### Steps to test

1. Run the project locally
2. Go to nodes or endpoints page


