### PR TITLE
fix(hasura): regenerate migration to get a partial ATH

### DIFF
--- a/hasura/migrations/default/1701711193753_create_evm_stats_view_v5/down.sql
+++ b/hasura/migrations/default/1701711193753_create_evm_stats_view_v5/down.sql
@@ -1,11 +1,12 @@
 -- Could not auto-generate a down migration.
 -- Please write an appropriate down migration for the SQL below:
+-- DROP VIEW IF EXISTS "evm"."stats";
 -- CREATE OR REPLACE VIEW "evm"."stats" AS
 --  SELECT COALESCE(evm_block.avg_gas_used, (0)::numeric) AS block_gas_avg,
 --     COALESCE(daily_transactions.total_transaction_count, (0)::bigint) AS daily_transaction_count,
---     partial_ath.blocks AS ath_blocks,
 --     COALESCE((partial_ath.max_transaction_sum)::numeric, (0)::numeric) AS ath_transactions_count,
---     COALESCE(partial_ath.gas_used_sum, (0)::numeric) AS ath_gas_used
+--     COALESCE(partial_ath.gas_used_sum, (0)::numeric) AS ath_gas_used,
+--     partial_ath.blocks AS ath_blocks
 --    FROM ((( SELECT avg(subquery_alias.gas_used) AS avg_gas_used
 --            FROM ( SELECT block.gas_used,
 --                     block."timestamp"

--- a/hasura/migrations/default/1701711193753_create_evm_stats_view_v5/up.sql
+++ b/hasura/migrations/default/1701711193753_create_evm_stats_view_v5/up.sql
@@ -1,9 +1,10 @@
+DROP VIEW IF EXISTS "evm"."stats";
 CREATE OR REPLACE VIEW "evm"."stats" AS 
  SELECT COALESCE(evm_block.avg_gas_used, (0)::numeric) AS block_gas_avg,
     COALESCE(daily_transactions.total_transaction_count, (0)::bigint) AS daily_transaction_count,
-    partial_ath.blocks AS ath_blocks,
     COALESCE((partial_ath.max_transaction_sum)::numeric, (0)::numeric) AS ath_transactions_count,
-    COALESCE(partial_ath.gas_used_sum, (0)::numeric) AS ath_gas_used
+    COALESCE(partial_ath.gas_used_sum, (0)::numeric) AS ath_gas_used,
+    partial_ath.blocks AS ath_blocks
    FROM ((( SELECT avg(subquery_alias.gas_used) AS avg_gas_used
            FROM ( SELECT block.gas_used,
                     block."timestamp"

--- a/webapp/src/routes/EVMDashboard/index.js
+++ b/webapp/src/routes/EVMDashboard/index.js
@@ -143,7 +143,7 @@ const EVMDashboard = () => {
           loading={loading}
         >
           <BodyGraphValue
-            links={EVMStats?.tps_all_time_high?.blocks.map(block =>
+            links={(EVMStats?.tps_all_time_high?.blocks || []).map(block =>
               getEVMBlockNumUrl(block),
             )}
           />


### PR DESCRIPTION
### Regenerate migration to get a partial ATH

### What does this PR do?

- Remove the last migration and regenerate it, including the statement to drop the view if it exists 

### Steps to test

1. Run the project locally
2. Go to hasura console
3. Check the query from evm.stats view
