### PR TITLE
fix(webapp): set page title only if it exists

### DIFF
--- a/webapp/src/layouts/Dashboard.js
+++ b/webapp/src/layouts/Dashboard.js
@@ -115,9 +115,11 @@ const Dashboard = ({ children }) => {
                 networkName: eosConfig.networkLabel,
               }),
         pathname: pathName,
-        pageTitle: t(`${pathName}>title`, {
-          networkName: eosConfig.networkLabel,
-        }),
+        pageTitle: i18n.exists(`routes:${pathName}>title`)
+          ? t(`${pathName}>title`, {
+              networkName: eosConfig.networkLabel,
+            })
+          : '',
         useConnectWallet: Boolean(route.useConnectWallet),
       })
     } else {


### PR DESCRIPTION
### Check if page title exists

### What does this PR do?

- Resolve #1403

### Steps to test

1. Run the project locally
2. Go to an block producer profile
3. Use the developer tools to simulate a slow connection
4. Check the page title never is /block-producers/bpName>title

