### PR TITLE
feat(webapp): display fio address instead of owner value

### DIFF
--- a/webapp/src/components/GeoMap/CountryMap.js
+++ b/webapp/src/components/GeoMap/CountryMap.js
@@ -105,7 +105,7 @@ const ClusterMap = ({ data, map, mapCode }) => {
                 const producer = this?.point?.producer
 
                 return producer?.owner
-                  ? `<a href=/${eosConfig.producersRoute}/${producer?.owner}>${producer?.owner}</a>`
+                  ? `<a href=/${eosConfig.producersRoute}/${producer?.owner}>${producer?.fio_address || producer?.owner}</a>`
                   : ''
               },
             },

--- a/webapp/src/components/ProducersChart/index.js
+++ b/webapp/src/components/ProducersChart/index.js
@@ -105,7 +105,7 @@ const CustomBarLabel = memo(
           fontFamily="Roboto, Helvetica, Arial, sans-serif;"
           fontWeight={isProducing ? 'bold' : 'normal'}
         >
-          {payload.owner}
+          {payload.name ? payload.name?.replace('@fiotestnet','')?.substring(0, 12) + '...' : payload.owner}
         </text>
       )
 

--- a/webapp/src/gql/producer.gql.js
+++ b/webapp/src/gql/producer.gql.js
@@ -20,6 +20,7 @@ export const PRODUCERS_QUERY = gql`
     ) {
       id
       owner
+      fio_address
       url
       total_votes
       bp_json
@@ -35,7 +36,6 @@ export const PRODUCERS_QUERY = gql`
         type
         value
       }
-      fio_address
     }
   }
 `
@@ -51,6 +51,7 @@ export const PRODUCER_INFO_QUERY = gql`
     ) {
       id
       owner
+      fio_address
       url
       bp_json
       total_votes_eos
@@ -91,6 +92,7 @@ export const SMALL_PRODUCERS_QUERY = gql`
     ) {
       id
       owner
+      fio_address
       url
       bp_json
       total_votes_eos
@@ -146,6 +148,7 @@ const NODES_OPERATION = type => gql`
     ) {
       id
       owner
+      fio_address
       rank
       producer_key
       bp_json
@@ -190,6 +193,7 @@ const ENDPOINTS_OPERATION = type => gql`
     ) {
       id
       owner
+      fio_address
       updated_at
       endpoints: endpoints_list(where: $endpointFilter, order_by: { value: asc }) {
         type
@@ -308,6 +312,7 @@ export const ALL_NODES_QUERY = gql`
     ) {
       id
       owner
+      fio_address
       bp_json
       updated_at
     }

--- a/webapp/src/hooks/customHooks/useEndpointsState.js
+++ b/webapp/src/hooks/customHooks/useEndpointsState.js
@@ -32,7 +32,8 @@ const useEndpointsState = () => {
         const inserted = []
 
         const bpName =
-          producer.bp_json?.org?.candidate_name ||
+          producer?.fio_address ||
+          producer?.bp_json?.org?.candidate_name ||
           producer?.bp_json?.org?.organization_name ||
           producer?.owner
 

--- a/webapp/src/routes/ProducerProfile/ProfileCard.js
+++ b/webapp/src/routes/ProducerProfile/ProfileCard.js
@@ -119,7 +119,7 @@ const ProfileCard = ({ producer }) => {
       <div className={classes.profile}>
         <ProducerName
           name={producer?.media?.name || producer?.owner}
-          account={producer?.media?.name ? producer?.owner : ''}
+          account={producer?.media?.name ? (producer?.fio_address || producer?.owner) : ''}
           text={t('BPonNetwork', {
             networkName: eosConfig.networkLabel,
             position: producer?.media?.account,


### PR DESCRIPTION
### Use the fio_address value instead of the owner

### Steps to test

1. Run the project locally using FIO configuration
2. Check the chart of the producers and BP profile pages

### Screenshot

![image](https://github.com/edenia/antelope-tools/assets/66583677/cce03366-cddf-4c68-a4ee-3c590bfc9b13)
